### PR TITLE
PWX-34977: Compilation fixes for 5.14.0-362 using source from 5.14.0-…

### DIFF
--- a/file.c
+++ b/file.c
@@ -2403,7 +2403,8 @@ static int btrfs_file_mmap(struct file	*filp, struct vm_area_struct *vma)
 {
 	struct address_space *mapping = filp->f_mapping;
 
-	if (!mapping->a_ops->readpage)
+	// JAR - 	if (!mapping->a_ops->readpage)
+	if (!mapping->a_ops->read_folio)
 		return -ENOEXEC;
 
 	file_accessed(filp);


### PR DESCRIPTION
…284.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Using btrfs source changes which build on 5.14.0-284.x rhel9.   Make changes to support 5.14.0-362.x rhel9.3.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-34977
**Special notes for your reviewer**:
These changes have already been tested and ran through distro test.

