### PR TITLE
Pwx 40665

### DIFF
--- a/dev-replace.c
+++ b/dev-replace.c
@@ -245,6 +245,7 @@ static int btrfs_init_dev_replace_tgtdev(struct btrfs_fs_info *fs_info,
 {
 	struct btrfs_fs_devices *fs_devices = fs_info->fs_devices;
 	struct btrfs_device *device;
+	struct file *bdev_file;
 	struct block_device *bdev;
 	struct rcu_string *name;
 	u64 devid = BTRFS_DEV_REPLACE_DEVID;
@@ -256,14 +257,22 @@ static int btrfs_init_dev_replace_tgtdev(struct btrfs_fs_info *fs_info,
 		return -EINVAL;
 	}
 
+	// Sebas: blkdev_get_by_path is not present
+	bdev_file = bdev_file_open_by_path(device_path, BLK_OPEN_WRITE,
+					fs_info->bdev_holder, NULL);
+	if (IS_ERR(bdev_file)) {
+		btrfs_err(fs_info, "target device %s is invalid!", device_path);
+		return PTR_ERR(bdev_file);
+	}
+	bdev = file_bdev(bdev_file);
 	// JAR bdev = blkdev_get_by_path(device_path, FMODE_WRITE | FMODE_EXCL,
 	//			  fs_info->bdev_holder);
-	bdev = blkdev_get_by_path(device_path, BLK_OPEN_WRITE,
-				  fs_info->bdev_holder, NULL);
-	if (IS_ERR(bdev)) {
-		btrfs_err(fs_info, "target device %s is invalid!", device_path);
-		return PTR_ERR(bdev);
-	}
+	//bdev = blkdev_get_by_path(device_path, BLK_OPEN_WRITE,
+	//			  fs_info->bdev_holder, NULL);
+	//if (IS_ERR(bdev)) {
+	//	btrfs_err(fs_info, "target device %s is invalid!", device_path);
+	//	return PTR_ERR(bdev);
+	//}
 
 	if (!btrfs_check_device_zone_type(fs_info, bdev)) {
 		btrfs_err(fs_info,
@@ -342,8 +351,9 @@ static int btrfs_init_dev_replace_tgtdev(struct btrfs_fs_info *fs_info,
 	return 0;
 
 error:
+	// Sebas : blkdev_put is not present
 	// JAR blkdev_put(bdev, FMODE_EXCL);
-	blkdev_put(bdev, fs_info->bdev_holder);
+	// blkdev_put(bdev, fs_info->bdev_holder);
 	return ret;
 }
 

--- a/dev-replace.c
+++ b/dev-replace.c
@@ -351,6 +351,7 @@ static int btrfs_init_dev_replace_tgtdev(struct btrfs_fs_info *fs_info,
 	return 0;
 
 error:
+	fput(bdev_file);
 	// Sebas : blkdev_put is not present
 	// JAR blkdev_put(bdev, FMODE_EXCL);
 	// blkdev_put(bdev, fs_info->bdev_holder);

--- a/file.c
+++ b/file.c
@@ -1593,8 +1593,9 @@ static int btrfs_write_check(struct kiocb *iocb, struct iov_iter *from,
 		if (nocow_bytes < count)
 			return -EAGAIN;
 	}
-
-	current->backing_dev_info = inode_to_bdi(inode);
+	// Sebas: nothing can be done here other than commenting out the code
+	// since task_struct can't be modified
+	// current->backing_dev_info = inode_to_bdi(inode);
 	ret = file_remove_privs(file);
 	if (ret)
 		return ret;
@@ -1615,7 +1616,9 @@ static int btrfs_write_check(struct kiocb *iocb, struct iov_iter *from,
 
 		ret = btrfs_cont_expand(BTRFS_I(inode), oldsize, end_pos);
 		if (ret) {
-			current->backing_dev_info = NULL;
+			// Sebas: nothing can be done here other than commenting out the code
+			// since task_struct can't be modified
+			// current->backing_dev_info = NULL;
 			return ret;
 		}
 	}
@@ -2112,7 +2115,9 @@ ssize_t btrfs_do_write_iter(struct kiocb *iocb, struct iov_iter *from,
 	if (sync)
 		atomic_dec(&inode->sync_writers);
 
-	current->backing_dev_info = NULL;
+	// Sebas: nothing can be done here other than commenting out the code
+	// since task_struct can't be modified
+	// current->backing_dev_info = NULL;
 	return num_written;
 }
 

--- a/ioctl.c
+++ b/ioctl.c
@@ -3590,9 +3590,10 @@ static long btrfs_ioctl_rm_dev_v2(struct file *file, void __user *arg)
 	}
 err_drop:
 	mnt_drop_write_file(file);
-	if (bdev)
+	// Sebas : blkdev_put is not present
+	// if (bdev)
 	  // JAR blkdev_put(bdev, mode);
-	  blkdev_put(bdev, holder);
+	  // blkdev_put(bdev, holder);
 out:
 	btrfs_put_dev_args_from_path(&args);
 	kfree(vol_args);
@@ -3643,9 +3644,10 @@ static long btrfs_ioctl_rm_dev(struct file *file, void __user *arg)
 	}
 
 	mnt_drop_write_file(file);
-	if (bdev)
+	// Sebas : blkdev_put is not present
+	// if (bdev)
 	  //blkdev_put(bdev, mode);
-	  blkdev_put(bdev, holder);
+	  // blkdev_put(bdev, holder);
 out:
 	btrfs_put_dev_args_from_path(&args);
 	kfree(vol_args);

--- a/ioctl.c
+++ b/ioctl.c
@@ -3535,8 +3535,10 @@ static long btrfs_ioctl_rm_dev_v2(struct file *file, void __user *arg)
 	struct inode *inode = file_inode(file);
 	struct btrfs_fs_info *fs_info = btrfs_sb(inode->i_sb);
 	struct btrfs_ioctl_vol_args_v2 *vol_args;
-	struct block_device *bdev = NULL;
-	fmode_t mode;
+	// Sebas : use bdev_file
+	struct file *bdev_file = NULL;
+	// struct block_device *bdev = NULL;
+	// fmode_t mode;
 	// JAR -- added void *holder;
 	void *holder;
 	int ret;
@@ -3576,7 +3578,7 @@ static long btrfs_ioctl_rm_dev_v2(struct file *file, void __user *arg)
 
 	/* Exclusive operation is now claimed */
 	// JAR -- added &holder
-	ret = btrfs_rm_device(fs_info, &args, &bdev, &mode, &holder);
+	ret = btrfs_rm_device(fs_info, &args, &bdev_file, &holder);
 
 	btrfs_exclop_finish(fs_info);
 
@@ -3594,6 +3596,8 @@ err_drop:
 	// if (bdev)
 	  // JAR blkdev_put(bdev, mode);
 	  // blkdev_put(bdev, holder);
+	if (bdev_file != NULL)
+		fput(bdev_file);
 out:
 	btrfs_put_dev_args_from_path(&args);
 	kfree(vol_args);
@@ -3606,10 +3610,12 @@ static long btrfs_ioctl_rm_dev(struct file *file, void __user *arg)
 	struct inode *inode = file_inode(file);
 	struct btrfs_fs_info *fs_info = btrfs_sb(inode->i_sb);
 	struct btrfs_ioctl_vol_args *vol_args;
-	struct block_device *bdev = NULL;
+	// sebas : use bdev_file
+	struct file* bdev_file = NULL;
+	// struct block_device *bdev = NULL;
 	// JAR -- added below
 	void *holder;
-	fmode_t mode;
+	// fmode_t mode;
 	int ret;
 	bool cancel = false;
 
@@ -3637,7 +3643,8 @@ static long btrfs_ioctl_rm_dev(struct file *file, void __user *arg)
 					   cancel);
 	if (ret == 0) {
 	  // JAR -- added &holder
-	  ret = btrfs_rm_device(fs_info, &args, &bdev, &mode, &holder);
+	  // Sebas: use bdev_file
+	  ret = btrfs_rm_device(fs_info, &args, &bdev_file, &holder);
 		if (!ret)
 			btrfs_info(fs_info, "disk deleted %s", vol_args->name);
 		btrfs_exclop_finish(fs_info);
@@ -3648,6 +3655,8 @@ static long btrfs_ioctl_rm_dev(struct file *file, void __user *arg)
 	// if (bdev)
 	  //blkdev_put(bdev, mode);
 	  // blkdev_put(bdev, holder);
+	if (bdev_file != NULL)
+		fput(bdev_file);
 out:
 	btrfs_put_dev_args_from_path(&args);
 	kfree(vol_args);

--- a/relocation.c
+++ b/relocation.c
@@ -2966,8 +2966,10 @@ static int relocate_one_page(struct inode *inode, struct file_ra_state *ra,
 	if (ret < 0)
 		goto release_page;
 
+	// Sebas: convert a page to a folio because page_cache_async_readahead
+	// expects a folio instead of a page
 	if (PageReadahead(page))
-		page_cache_async_readahead(inode->i_mapping, ra, NULL, page,
+		page_cache_async_readahead(inode->i_mapping, ra, NULL, page_folio(page),
 				   page_index, last_index + 1 - page_index);
 
 	if (!PageUptodate(page)) {

--- a/send.c
+++ b/send.c
@@ -4985,8 +4985,10 @@ static int put_file_data(struct send_ctx *sctx, u64 offset, u32 len)
 		}
 
 		if (PageReadahead(page)) {
+			// Sebas : convert a page to folio since the page_cache_async_readahead
+			// expects a folio
 			page_cache_async_readahead(inode->i_mapping, &sctx->ra,
-				NULL, page, index, last_index + 1 - index);
+				NULL, page_folio(page), index, last_index + 1 - index);
 		}
 
 		if (!PageUptodate(page)) {

--- a/verity.c
+++ b/verity.c
@@ -775,6 +775,10 @@ again:
 	return page;
 }
 
+// Sebas: commented out this version because
+// the last arg is log_blocksize and expected
+// arg type is unsigned int
+#if 0
 /*
  * fsverity op that writes a Merkle tree block into the btree.
  *
@@ -802,6 +806,34 @@ static int btrfs_write_merkle_tree_block(struct inode *inode, const void *buf,
 
 	return write_key_bytes(BTRFS_I(inode), BTRFS_VERITY_MERKLE_ITEM_KEY,
 			       off, buf, len);
+}
+#endif
+
+// Sebas: this version seems to match the function decl
+//     int (*write_merkle_tree_block)(struct inode *inode, const void *buf,
+//                       u64 pos, unsigned int size);
+/*
+ * fsverity op that writes a Merkle tree block into the btree.
+ *
+ * @inode:	inode to write a Merkle tree block for
+ * @buf:	Merkle tree block to write
+ * @pos:	the position of the block in the Merkle tree (in bytes)
+ * @size:	the Merkle tree block size (in bytes)
+ *
+ * Returns 0 on success or negative error code on failure
+ */
+static int btrfs_write_merkle_tree_block(struct inode *inode, const void *buf,
+					 u64 pos, unsigned int size)
+{
+	loff_t merkle_pos = merkle_file_pos(inode);
+
+	if (merkle_pos < 0)
+		return merkle_pos;
+	if (merkle_pos > inode->i_sb->s_maxbytes - pos - size)
+		return -EFBIG;
+
+	return write_key_bytes(BTRFS_I(inode), BTRFS_VERITY_MERKLE_ITEM_KEY,
+			       pos, buf, size);
 }
 
 const struct fsverity_operations btrfs_verityops = {

--- a/volumes.c
+++ b/volumes.c
@@ -2079,31 +2079,6 @@ static u64 btrfs_num_devices(struct btrfs_fs_info *fs_info)
 	return num_devices;
 }
 
-#if 0
-// Sebas : added code for v6.8
-static void btrfs_scratch_superblock(struct btrfs_fs_info *fs_info,
-				     struct block_device *bdev, int copy_num)
-{
-	struct btrfs_super_block *disk_super;
-	const size_t len = sizeof(disk_super->magic);
-	const u64 bytenr = btrfs_sb_offset(copy_num);
-	int ret;
-
-	disk_super = btrfs_read_disk_super(bdev, bytenr, bytenr);
-	if (IS_ERR(disk_super))
-		return;
-
-	memset(&disk_super->magic, 0, len);
-	folio_mark_dirty(virt_to_folio(disk_super));
-	btrfs_release_disk_super(disk_super);
-
-	ret = sync_blockdev_range(bdev, bytenr, bytenr + len - 1);
-	if (ret)
-		btrfs_warn(fs_info, "error clearing superblock number %d (%d)",
-			copy_num, ret);
-}
-#endif
-
 void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 			       struct block_device *bdev,
 			       const char *device_path)
@@ -2157,32 +2132,6 @@ void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 	/* Update ctime/mtime for device path for libblkid */
 	update_dev_time(device_path);
 }
-#if 0
-// Sebas : impl from 6.8 kernel
-void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
-			       struct block_device *bdev,
-			       const char *device_path)
-{
-	int copy_num;
-
-	if (!bdev)
-		return;
-
-	for (copy_num = 0; copy_num < BTRFS_SUPER_MIRROR_MAX; copy_num++) {
-		// Sebas : refactor
-		if (bdev_is_zoned(bdev))
-			btrfs_reset_sb_log_zones(bdev, copy_num);
-		else
-			btrfs_scratch_superblock(fs_info, bdev, copy_num);
-	}
-
-	/* Notify udev that device has changed */
-	btrfs_kobject_uevent(bdev, KOBJ_CHANGE);
-
-	/* Update ctime/mtime for device path for libblkid */
-	update_dev_time(device_path);
-}
-#endif
 
 int btrfs_rm_device(struct btrfs_fs_info *fs_info,
 		    struct btrfs_dev_lookup_args *args,

--- a/volumes.c
+++ b/volumes.c
@@ -525,19 +525,17 @@ static struct btrfs_fs_devices *find_fsid_with_metadata_uuid(
 //
 static int
 btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
-		      int flush, struct block_device **bdev,
+		      int flush, struct block_device **bdev, struct file** bdev_file,
 		      struct btrfs_super_block **disk_super)
 {
 	int ret;
 
-	struct file* bdev_file;
-
-	bdev_file = bdev_file_open_by_path(device_path, flags, holder, NULL);
-	if (IS_ERR(bdev_file)) {
-		ret = PTR_ERR(bdev_file);
+	*bdev_file = bdev_file_open_by_path(device_path, flags, holder, NULL);
+	if (IS_ERR(*bdev_file)) {
+		ret = PTR_ERR(*bdev_file);
 		goto error;
 	}
-	*bdev = file_bdev(bdev_file);
+	*bdev = file_bdev(*bdev_file);
 
 	// JAR *bdev = blkdev_get_by_path(device_path, flags, holder);
 	// Sebas : the below API doesn't exist
@@ -547,10 +545,10 @@ btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 		sync_blockdev(*bdev);
 	ret = set_blocksize(*bdev, BTRFS_BDEV_BLOCKSIZE);
 	if (ret) {
-	  // JAR blkdev_put(*bdev, flags);
-	  // Sebas : the below API doesn't exist
-	  // blkdev_put(*bdev, holder);
-	    fput(bdev_file);
+	    // JAR blkdev_put(*bdev, flags);
+	    // Sebas : the below API doesn't exist
+	    // blkdev_put(*bdev, holder);
+	    fput(*bdev_file);
 		goto error;
 	}
 	invalidate_bdev(*bdev);
@@ -559,7 +557,7 @@ btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 		ret = PTR_ERR(*disk_super);
 		// JAR blkdev_put(*bdev, flags);
 		// blkdev_put(*bdev, holder);
-		fput(bdev_file);
+		fput(*bdev_file);
 		goto error;
 	}
 
@@ -568,6 +566,7 @@ btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 error:
 	*disk_super = NULL;
 	*bdev = NULL;
+	*bdev_file = NULL;
 	return ret;
 }
 
@@ -643,6 +642,8 @@ static int btrfs_open_one_device(struct btrfs_fs_devices *fs_devices,
 	struct btrfs_super_block *disk_super;
 	u64 devid;
 	int ret;
+	// Sebas : added this
+	struct file* bdev_file;
 
 	if (device->bdev)
 		return -EINVAL;
@@ -650,7 +651,7 @@ static int btrfs_open_one_device(struct btrfs_fs_devices *fs_devices,
 		return -EINVAL;
 
 	ret = btrfs_get_bdev_and_sb(device->name->str, flags, holder, 1,
-				    &bdev, &disk_super);
+				    &bdev, &bdev_file, &disk_super);
 	if (ret)
 		return ret;
 
@@ -704,6 +705,7 @@ error_free_page:
 	// Sebas : blkdev_put doesn't exist
 	// JAR blkdev_put(bdev, flags);
 	// blkdev_put(bdev, holder);
+	fput(bdev_file);
 
 	return -EINVAL;
 }
@@ -2400,6 +2402,7 @@ int btrfs_get_dev_args_from_path(struct btrfs_fs_info *fs_info,
 {
 	struct btrfs_super_block *disk_super;
 	struct block_device *bdev;
+	struct file* bdev_file;
 	int ret;
 
 	if (!path || !path[0])
@@ -2418,7 +2421,7 @@ int btrfs_get_dev_args_from_path(struct btrfs_fs_info *fs_info,
 
 	// JAR ret = btrfs_get_bdev_and_sb(path, FMODE_READ, fs_info->bdev_holder, 0,
 	ret = btrfs_get_bdev_and_sb(path,  BLK_OPEN_READ, fs_info->bdev_holder, 0,
-				    &bdev, &disk_super);
+				    &bdev, &bdev_file, &disk_super);
 	if (ret)
 		return ret;
 	args->devid = btrfs_stack_device_id(&disk_super->dev_item);
@@ -2431,6 +2434,7 @@ int btrfs_get_dev_args_from_path(struct btrfs_fs_info *fs_info,
 	// Sebas : blkdev_put is not present
 	// JAR blkdev_put(bdev, FMODE_READ);
 	// blkdev_put(bdev, NULL);
+	fput(bdev_file);
 	return 0;
 }
 

--- a/volumes.c
+++ b/volumes.c
@@ -505,6 +505,24 @@ static struct btrfs_fs_devices *find_fsid_with_metadata_uuid(
 }
 
 
+// Sebas - blkdev_get_by_path is not present, so the only thing we can
+// do is to get the bdev_file and then get the struct block_device* from it
+// but to get the bdev_file requires a blk_mode_t flags, so ideally need to convert
+// fmode_t to blk_mode_t but it might not be necessary
+// The callers of btrfs_get_bdev_and_sb are
+// btrfs_get_dev_args_from_path and btrfs_open_one_device
+//
+// btrfs_get_dev_args_from_path calls btrfs_get_bdev_and_sb with BLK_OPEN_READ
+//
+// open_seed_devices calls open_fs_devices with BLK_OPEN_READ which in turn calls btrfs_open_one_device
+//
+// btrfs_mount_root calls btrfs_open_devices (can have BLK_OPEN_READ | BLK_OPEN_WRITE) which in turn calls
+// open_fs_devices and it calls btrfs_open_one_device
+//
+// the point is : the only flags here is BLK_OPEN_READ and BLK_OPEN_WRITE
+// which has the same value as FMODE_READ and FMODE_WRITE and so blk_mode_t flags
+// can be used interchangeably with fmode_t here
+//
 static int
 btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 		      int flush, struct block_device **bdev,
@@ -512,20 +530,27 @@ btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 {
 	int ret;
 
-	// JAR *bdev = blkdev_get_by_path(device_path, flags, holder);
-	*bdev = blkdev_get_by_path(device_path, flags, holder, NULL);
+	struct file* bdev_file;
 
-	if (IS_ERR(*bdev)) {
-		ret = PTR_ERR(*bdev);
+	bdev_file = bdev_file_open_by_path(device_path, flags, holder, NULL);
+	if (IS_ERR(bdev_file)) {
+		ret = PTR_ERR(bdev_file);
 		goto error;
 	}
+	*bdev = file_bdev(bdev_file);
+
+	// JAR *bdev = blkdev_get_by_path(device_path, flags, holder);
+	// Sebas : the below API doesn't exist
+    // *bdev = blkdev_get_by_path(device_path, flags, holder, NULL);
 
 	if (flush)
 		sync_blockdev(*bdev);
 	ret = set_blocksize(*bdev, BTRFS_BDEV_BLOCKSIZE);
 	if (ret) {
 	  // JAR blkdev_put(*bdev, flags);
-	  blkdev_put(*bdev, holder);
+	  // Sebas : the below API doesn't exist
+	  // blkdev_put(*bdev, holder);
+	    fput(bdev_file);
 		goto error;
 	}
 	invalidate_bdev(*bdev);
@@ -533,13 +558,15 @@ btrfs_get_bdev_and_sb(const char *device_path, fmode_t flags, void *holder,
 	if (IS_ERR(*disk_super)) {
 		ret = PTR_ERR(*disk_super);
 		// JAR blkdev_put(*bdev, flags);
-		blkdev_put(*bdev, holder);
+		// blkdev_put(*bdev, holder);
+		fput(bdev_file);
 		goto error;
 	}
 
 	return 0;
 
 error:
+	*disk_super = NULL;
 	*bdev = NULL;
 	return ret;
 }
@@ -674,8 +701,9 @@ static int btrfs_open_one_device(struct btrfs_fs_devices *fs_devices,
 
 error_free_page:
 	btrfs_release_disk_super(disk_super);
+	// Sebas : blkdev_put doesn't exist
 	// JAR blkdev_put(bdev, flags);
-	blkdev_put(bdev, holder);
+	// blkdev_put(bdev, holder);
 
 	return -EINVAL;
 }
@@ -1066,8 +1094,9 @@ static void __btrfs_free_extra_devids(struct btrfs_fs_devices *fs_devices,
 			continue;
 
 		if (device->bdev) {
+		  // Sebas : blkdev_put doesn't exist
 		  // JAR blkdev_put(device->bdev, device->mode);
-		  blkdev_put(device->bdev, device->holder);
+		  // blkdev_put(device->bdev, device->holder);
 			device->bdev = NULL;
 			fs_devices->open_devices--;
 		}
@@ -1114,7 +1143,7 @@ static void btrfs_close_bdev(struct btrfs_device *device)
 	}
 
 	// JAR blkdev_put(device->bdev, device->mode);
-	blkdev_put(device->bdev, device->holder);
+	// blkdev_put(device->bdev, device->holder);
 }
 
 static void btrfs_close_one_device(struct btrfs_device *device)
@@ -1355,6 +1384,10 @@ struct btrfs_device *btrfs_scan_one_device(const char *path, fmode_t flags,
 	struct block_device *bdev;
 	u64 bytenr, bytenr_orig;
 	int ret;
+	// Sebas : blkdev_get_by_path is not present
+	// need to use bdev_file_open_by_path which
+	// returns a bdev_file
+	struct file *bdev_file;
 
 	lockdep_assert_held(&uuid_mutex);
 
@@ -1367,10 +1400,16 @@ struct btrfs_device *btrfs_scan_one_device(const char *path, fmode_t flags,
 	// JAR flags |= FMODE_EXCL;
 
 	// JAR bdev = blkdev_get_by_path(path, flags, holder);
-	bdev = blkdev_get_by_path(path, flags, NULL, NULL);
-	if (IS_ERR(bdev))
-		return ERR_CAST(bdev);
+	// Sebas : blkdev_get_by_path not present
+	// bdev = blkdev_get_by_path(path, flags, NULL, NULL);
+	// if (IS_ERR(bdev))
+	//	return ERR_CAST(bdev);
+	bdev_file =  bdev_file_open_by_path(path, flags, NULL, NULL);
+	if (IS_ERR(bdev_file))
+		return ERR_CAST(bdev_file);
 
+	// Sebas : get block_device* from bdev_file
+	bdev = file_bdev(bdev_file);
 	bytenr_orig = btrfs_sb_offset(0);
 	ret = btrfs_sb_log_location_bdev(bdev, 0, READ, &bytenr);
 	if (ret) {
@@ -1392,7 +1431,9 @@ struct btrfs_device *btrfs_scan_one_device(const char *path, fmode_t flags,
 
 error_bdev_put:
 	// JAR blkdev_put(bdev, flags);
-	blkdev_put(bdev, NULL);
+	// blkdev_put(bdev, NULL);
+	// Sebas : fput on error
+	fput(bdev_file);
 	return device;
 }
 
@@ -2031,42 +2072,44 @@ static u64 btrfs_num_devices(struct btrfs_fs_info *fs_info)
 	return num_devices;
 }
 
+// Sebas : added code for refactor
+static void btrfs_scratch_superblock(struct btrfs_fs_info *fs_info,
+				     struct block_device *bdev, int copy_num)
+{
+	struct btrfs_super_block *disk_super;
+	const size_t len = sizeof(disk_super->magic);
+	const u64 bytenr = btrfs_sb_offset(copy_num);
+	int ret;
+
+	disk_super = btrfs_read_disk_super(bdev, bytenr, bytenr);
+	if (IS_ERR(disk_super))
+		return;
+
+	memset(&disk_super->magic, 0, len);
+	folio_mark_dirty(virt_to_folio(disk_super));
+	btrfs_release_disk_super(disk_super);
+
+	ret = sync_blockdev_range(bdev, bytenr, bytenr + len - 1);
+	if (ret)
+		btrfs_warn(fs_info, "error clearing superblock number %d (%d)",
+			copy_num, ret);
+}
+
 void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 			       struct block_device *bdev,
 			       const char *device_path)
 {
-	struct btrfs_super_block *disk_super;
 	int copy_num;
 
 	if (!bdev)
 		return;
 
 	for (copy_num = 0; copy_num < BTRFS_SUPER_MIRROR_MAX; copy_num++) {
-		struct page *page;
-		int ret;
-
-		disk_super = btrfs_read_dev_one_super(bdev, copy_num);
-		if (IS_ERR(disk_super))
-			continue;
-
-		if (bdev_is_zoned(bdev)) {
+		// Sebas : refactor
+		if (bdev_is_zoned(bdev))
 			btrfs_reset_sb_log_zones(bdev, copy_num);
-			continue;
-		}
-
-		memset(&disk_super->magic, 0, sizeof(disk_super->magic));
-
-		page = virt_to_page(disk_super);
-		set_page_dirty(page);
-		lock_page(page);
-		/* write_on_page() unlocks the page */
-		ret = write_one_page(page);
-		if (ret)
-			btrfs_warn(fs_info,
-				"error clearing superblock number %d (%d)",
-				copy_num, ret);
-		btrfs_release_disk_super(disk_super);
-
+		else
+			btrfs_scratch_superblock(fs_info, bdev, copy_num);
 	}
 
 	/* Notify udev that device has changed */
@@ -2385,8 +2428,9 @@ int btrfs_get_dev_args_from_path(struct btrfs_fs_info *fs_info,
 	else
 		memcpy(args->fsid, disk_super->fsid, BTRFS_FSID_SIZE);
 	btrfs_release_disk_super(disk_super);
+	// Sebas : blkdev_put is not present
 	// JAR blkdev_put(bdev, FMODE_READ);
-	blkdev_put(bdev, NULL);
+	// blkdev_put(bdev, NULL);
 	return 0;
 }
 
@@ -2607,6 +2651,7 @@ int btrfs_init_new_device(struct btrfs_fs_info *fs_info, const char *device_path
 	struct btrfs_trans_handle *trans;
 	struct btrfs_device *device;
 	struct block_device *bdev;
+	struct file* bdev_file;
 	struct super_block *sb = fs_info->sb;
 	struct rcu_string *name;
 	struct btrfs_fs_devices *fs_devices = fs_info->fs_devices;
@@ -2620,12 +2665,19 @@ int btrfs_init_new_device(struct btrfs_fs_info *fs_info, const char *device_path
 	if (sb_rdonly(sb) && !fs_devices->seeding)
 		return -EROFS;
 
+	bdev_file = bdev_file_open_by_path(device_path, BLK_OPEN_WRITE,
+					fs_info->bdev_holder, NULL);
+	if (IS_ERR(bdev_file))
+		return PTR_ERR(bdev_file);
+	bdev = file_bdev(bdev_file);
+
+	// Sebas : blkdev_get_by_path is not present
 	// JAR bdev = blkdev_get_by_path(device_path, FMODE_WRITE | FMODE_EXCL,
 	// 		  fs_info->bdev_holder);
-	bdev = blkdev_get_by_path(device_path, BLK_OPEN_WRITE,
-				  fs_info->bdev_holder, NULL);
-	if (IS_ERR(bdev))
-		return PTR_ERR(bdev);
+	// bdev = blkdev_get_by_path(device_path, BLK_OPEN_WRITE,
+	//			  fs_info->bdev_holder, NULL);
+	// if (IS_ERR(bdev))
+	//	return PTR_ERR(bdev);
 
 	if (!btrfs_check_device_zone_type(fs_info, bdev)) {
 		ret = -EINVAL;
@@ -2853,7 +2905,9 @@ error_free_device:
 	btrfs_free_device(device);
 error:
 	// JAR blkdev_put(bdev, FMODE_EXCL);
-	blkdev_put(bdev, fs_info->bdev_holder);
+	// Sebas : blkdev_put is not present
+	// blkdev_put(bdev, fs_info->bdev_holder);
+	fput(bdev_file);
 	if (locked) {
 		mutex_unlock(&uuid_mutex);
 		up_write(&sb->s_umount);

--- a/volumes.c
+++ b/volumes.c
@@ -2079,7 +2079,8 @@ static u64 btrfs_num_devices(struct btrfs_fs_info *fs_info)
 	return num_devices;
 }
 
-// Sebas : added code for refactor
+#if 0
+// Sebas : added code for v6.8
 static void btrfs_scratch_superblock(struct btrfs_fs_info *fs_info,
 				     struct block_device *bdev, int copy_num)
 {
@@ -2101,7 +2102,63 @@ static void btrfs_scratch_superblock(struct btrfs_fs_info *fs_info,
 		btrfs_warn(fs_info, "error clearing superblock number %d (%d)",
 			copy_num, ret);
 }
+#endif
 
+void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
+			       struct block_device *bdev,
+			       const char *device_path)
+{
+	struct btrfs_super_block *disk_super;
+	int copy_num;
+
+	if (!bdev)
+		return;
+
+	for (copy_num = 0; copy_num < BTRFS_SUPER_MIRROR_MAX; copy_num++) {
+		// Sebas: use folio instead of page
+		// struct page *page;
+		int ret;
+		// Sebas : added code for use in sync_blockdev_range
+		const size_t len = sizeof(disk_super->magic);
+		const u64 bytenr = btrfs_sb_offset(copy_num);
+
+		disk_super = btrfs_read_dev_one_super(bdev, copy_num);
+		if (IS_ERR(disk_super))
+			continue;
+
+		if (bdev_is_zoned(bdev)) {
+			btrfs_reset_sb_log_zones(bdev, copy_num);
+			continue;
+		}
+
+		memset(&disk_super->magic, 0, sizeof(disk_super->magic));
+
+		// Sebas : refactor from 6.8 kernel
+		// the idea is to try to change only the kernel APIs and
+		// not btrfs APIs
+		folio_mark_dirty(virt_to_folio(disk_super));
+		btrfs_release_disk_super(disk_super);
+		ret = sync_blockdev_range(bdev, bytenr, bytenr + len - 1);
+		// page = virt_to_page(disk_super);
+		// set_page_dirty(page);
+		// lock_page(page);
+		/* write_on_page() unlocks the page */
+		// ret = write_one_page(page);
+		if (ret)
+			btrfs_warn(fs_info,
+				"error clearing superblock number %d (%d)",
+				copy_num, ret);
+		// btrfs_release_disk_super(disk_super);
+	}
+
+	/* Notify udev that device has changed */
+	btrfs_kobject_uevent(bdev, KOBJ_CHANGE);
+
+	/* Update ctime/mtime for device path for libblkid */
+	update_dev_time(device_path);
+}
+#if 0
+// Sebas : impl from 6.8 kernel
 void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 			       struct block_device *bdev,
 			       const char *device_path)
@@ -2125,6 +2182,7 @@ void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 	/* Update ctime/mtime for device path for libblkid */
 	update_dev_time(device_path);
 }
+#endif
 
 int btrfs_rm_device(struct btrfs_fs_info *fs_info,
 		    struct btrfs_dev_lookup_args *args,

--- a/volumes.c
+++ b/volumes.c
@@ -685,6 +685,8 @@ static int btrfs_open_one_device(struct btrfs_fs_devices *fs_devices,
 		fs_devices->rotating = true;
 
 	device->bdev = bdev;
+	// Sebas: add for proper cleanup during unmount
+	device->bdev_file = bdev_file;
 	clear_bit(BTRFS_DEV_STATE_IN_FS_METADATA, &device->dev_state);
 	device->mode = flags;
 	// JAR -- Added below

--- a/volumes.c
+++ b/volumes.c
@@ -1095,10 +1095,12 @@ static void __btrfs_free_extra_devids(struct btrfs_fs_devices *fs_devices,
 		if (device->devid == BTRFS_DEV_REPLACE_DEVID)
 			continue;
 
-		if (device->bdev) {
-		  // Sebas : blkdev_put doesn't exist
-		  // JAR blkdev_put(device->bdev, device->mode);
-		  // blkdev_put(device->bdev, device->holder);
+		if (device->bdev_file) {
+		    // Sebas : blkdev_put doesn't exist
+		    // JAR blkdev_put(device->bdev, device->mode);
+		    // blkdev_put(device->bdev, device->holder);
+		    fput(device->bdev_file);
+			device->bdev_file = NULL;
 			device->bdev = NULL;
 			fs_devices->open_devices--;
 		}
@@ -1145,7 +1147,10 @@ static void btrfs_close_bdev(struct btrfs_device *device)
 	}
 
 	// JAR blkdev_put(device->bdev, device->mode);
+	// Sebas : blkdev_put is not present, replace with fput
 	// blkdev_put(device->bdev, device->holder);
+	if (device->bdev_file)
+		fput(device->bdev_file);
 }
 
 static void btrfs_close_one_device(struct btrfs_device *device)
@@ -2722,6 +2727,8 @@ int btrfs_init_new_device(struct btrfs_fs_info *fs_info, const char *device_path
 	rcu_assign_pointer(device->name, name);
 
 	device->fs_info = fs_info;
+	// Sebas: initialize bdev_file, needed for cleanup
+	device->bdev_file = bdev_file;
 	device->bdev = bdev;
 	ret = lookup_bdev(device_path, &device->devt);
 	if (ret)

--- a/volumes.c
+++ b/volumes.c
@@ -2186,7 +2186,7 @@ void btrfs_scratch_superblocks(struct btrfs_fs_info *fs_info,
 
 int btrfs_rm_device(struct btrfs_fs_info *fs_info,
 		    struct btrfs_dev_lookup_args *args,
-		    struct block_device **bdev, fmode_t *mode, void **holder)
+		    struct file **bdev_file, void **holder)
 {
 	struct btrfs_trans_handle *trans;
 	struct btrfs_device *device;
@@ -2324,8 +2324,11 @@ int btrfs_rm_device(struct btrfs_fs_info *fs_info,
 		}
 	}
 
-	*bdev = device->bdev;
-	*mode = device->mode;
+	// Sebas: need only the bdev_file
+	// for cleanup in the caller
+	//*bdev = device->bdev;
+	//*mode = device->mode;
+	*bdev_file = device->bdev_file;
 	// JAR -- added below
 	*holder = device->holder;
 	synchronize_rcu();

--- a/volumes.h
+++ b/volumes.h
@@ -65,6 +65,10 @@ struct btrfs_device {
 
 	u64 generation;
 
+	// Sebas: need bdev_file for cleanup in
+	// __btrfs_free_extra_devids and btrfs_close_bdev
+	// bdev_file is assigned in btrfs_init_new_device
+	struct file *bdev_file;
 	struct block_device *bdev;
 
 	struct btrfs_zoned_device_info *zone_info;

--- a/volumes.h
+++ b/volumes.h
@@ -539,7 +539,7 @@ void btrfs_put_dev_args_from_path(struct btrfs_dev_lookup_args *args);
 void btrfs_free_device(struct btrfs_device *device);
 int btrfs_rm_device(struct btrfs_fs_info *fs_info,
 		    struct btrfs_dev_lookup_args *args,
-		    struct block_device **bdev, fmode_t *mode, void **holder);
+		    struct file **bdev_file, void **holder);
 void __exit btrfs_cleanup_fs_uuids(void);
 int btrfs_num_copies(struct btrfs_fs_info *fs_info, u64 logical, u64 len);
 int btrfs_grow_device(struct btrfs_trans_handle *trans,

--- a/zoned.h
+++ b/zoned.h
@@ -16,6 +16,37 @@
  */
 #define BTRFS_DEFAULT_RECLAIM_THRESH		75
 
+// Sebas - add missing functionality
+/*
+ * Zoned block device models (zoned limit).
+ *
+ * Note: This needs to be ordered from the least to the most severe
+ * restrictions for the inheritance in blk_stack_limits() to work.
+ */
+enum blk_zoned_model {
+	BLK_ZONED_NONE = 0,	/* Regular block device */
+	BLK_ZONED_HA,		/* Host-aware zoned block device */
+	BLK_ZONED_HM,		/* Host-managed zoned block device */
+};
+
+static inline enum blk_zoned_model
+blk_queue_zoned_model(struct request_queue *q)
+{
+	if (IS_ENABLED(CONFIG_BLK_DEV_ZONED))
+		return q->limits.zoned;
+	return BLK_ZONED_NONE;
+}
+
+static inline enum blk_zoned_model bdev_zoned_model(struct block_device *bdev)
+{
+	struct request_queue *q = bdev_get_queue(bdev);
+
+	if (q)
+		return blk_queue_zoned_model(q);
+
+	return BLK_ZONED_NONE;
+}
+
 struct btrfs_zoned_device_info {
 	/*
 	 * Number of zones, zone size and types of zones if bdev is a


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add support for btrfs kernel module for RHEL kernel version (5.14.0-503.15.1)


**Which issue(s) this PR fixes** (optional)

**Special notes for your reviewer**:

Tested these changes with btrfs-progs
make test
    [TEST]   fsck-tests.sh
    [TEST/fsck]   001-bad-file-extent-bytenr
    [TEST/fsck]   002-bad-transid
    [TEST/fsck]   003-shift-offsets
    [TEST/fsck]   004-no-dir-index
    [TEST/fsck]   005-bad-item-offset
    [TEST/fsck]   006-bad-root-items
    [TEST/fsck]   007-bad-offset-snapshots
    [TEST/fsck]   008-bad-dir-index-name
    [TEST/fsck]   009-no-dir-item-or-index
    [TEST/fsck]   010-no-rootdir-inode-item
    [TEST/fsck]   011-no-inode-item
    [TEST/fsck]   012-leaf-corruption
    [TEST/fsck]   013-extent-tree-rebuild
    [TEST/fsck]   014-no-extent-info
    [TEST/fsck]   016-wrong-inode-nbytes
    [TEST/fsck]   017-missing-all-file-extent
    [TEST/fsck]   018-leaf-crossing-stripes
    [TEST/fsck]   019-non-skinny-false-alert
    [TEST/fsck]   020-extent-ref-cases
    [TEST/fsck]   021-partially-dropped-snapshot-case
    [TEST/fsck]   022-qgroup-rescan-halfway
    [TEST/fsck]   023-qgroup-stack-overflow
    [TEST/fsck]   024-clear-space-cache
./test.sh: line 2: confirm: command not found
    [TEST/fsck]   025-file-extents
    [TEST/fsck]   026-bad-dir-item-name
    [TEST/fsck]   027-bad-extent-inline-ref-type
    [TEST/fsck]   028-unaligned-super-dev-sizes
    [TEST/fsck]   029-valid-orphan-item
    [TEST/fsck]   030-reflinked-prealloc-extents
    [TEST/fsck]   031-metadatadump-check-data-csum
    [TEST/fsck]   032-corrupted-qgroup
    [TEST/fsck]   033-lowmem-collission-dir-items
    [TEST/fsck]   034-bad-inode-flags
    [TEST/fsck]   035-inline-bad-ram-bytes
    [TEST/fsck]   036-bad-dev-extents
    [TEST/fsck]   036-rescan-not-kicked-in
    [TEST/fsck]   037-freespacetree-repair
    [TEST/fsck]   038-missing-one-file-extent
    [TEST/fsck]   039-bad-inode-mode
    [TEST/fsck]   040-compressed-nodatasum
    [TEST/fsck]   041-invalid-root-generation
    [TEST/fsck]   042-half-dropped-inode
    [TEST/fsck]   043-bad-inode-generation
    [TEST/fsck]   044-invalid-extent-item-generation
    [TEST/fsck]   045-overlap-csum-item
    [TEST/fsck]   046-ino-cache-clean
    [TEST/fsck]   047-dev-bytes-used
    [TEST/fsck]   049-dir-hard-link
    [TEST/fsck]   050-invalid-block-group-used
    [TEST/fsck]   051-invalid-super-bytes-used
    [TEST/fsck]   052-init-csum-tree
    [TEST/fsck]   053-bad-metadata-level
    [TEST/fsck]   054-orphan-directory
    [TEST/fsck]   055-super-num-devs-mismatch
    [TEST/fsck]   056-raid56-false-alerts
    [TEST/fsck]   057-seed-false-alerts
    [TEST]   mkfs-tests.sh
    [TEST/mkfs]   001-basic-profiles
    [TEST/mkfs]   002-no-force-mixed-on-small-volume
    [TEST/mkfs]   003-mixed-with-wrong-nodesize
    [TEST/mkfs]   004-rootdir-keeps-size
    [TEST/mkfs]   005-long-device-name-for-ssd
    [TEST/mkfs]   006-partitioned-loopdev
    [TEST/mkfs]   007-mix-nodesize-sectorsize
    [TEST/mkfs]   008-sectorsize-nodesize-combination
    [TEST/mkfs]   009-special-files-for-rootdir
    [TEST/mkfs]   010-minimal-size
    [TEST/mkfs]   011-rootdir-create-file
    [TEST/mkfs]   012-rootdir-no-shrink
    [TEST/mkfs]   013-reserved-1M-for-single
    [TEST/mkfs]   014-rootdir-inline-extent
    [TEST/mkfs]   015-fstree-uuid-otime
    [TEST/mkfs]   016-rootdir-bad-symbolic-link
    [TEST/mkfs]   017-small-backing-size-thin-provision-device
    [TEST/mkfs]   018-multidevice-overflow
    [TEST/mkfs]   019-basic-checksums-mkfs
    [TEST/mkfs]   020-basic-checksums-mount
    [TEST/mkfs]   021-rfeatures-quota-rootdir
    [TEST/mkfs]   022-rootdir-size
    [TEST/mkfs]   023-free-space-tree
    [TEST/mkfs]   024-fst-bitmaps
    [LD]     fssum
    [CC]     btrfs-find-root.o
    [LD]     btrfs-find-root
    [CC]     btrfs-select-super.o
    [LD]     btrfs-select-super
    [CC]     convert/source-ext2.o
    [CC]     convert/source-reiserfs.o
    [LD]     btrfs-convert
    [TEST]   misc-tests.sh
    [TEST/misc]   001-btrfstune-features
    [TEST/misc]   002-uuid-rewrite
    [TEST/misc]   003-zero-log
    [TEST/misc]   004-shrink-fs
    [TEST/misc]   005-convert-progress-thread-crash
    [TEST/misc]   006-image-on-missing-device
    [TEST/misc]   007-subvolume-sync
    [TEST/misc]   008-leaf-crossing-stripes
    [TEST/misc]   009-subvolume-sync-must-wait
    [TEST/misc]   010-convert-delete-ext2-subvol
    [TEST/misc]   011-delete-missing-device
    [TEST/misc]   012-find-root-no-result
    [TEST/misc]   013-subvolume-sync-crash
    [TEST/misc]   014-filesystem-label
    [TEST/misc]   015-dump-super-garbage
    [TEST/misc]   016-send-clone-src
    [TEST/misc]   017-recv-stream-malformatted
    [TEST/misc]   018-recv-end-of-stream
    [TEST/misc]   019-receive-clones-on-mounted-subvol
    [TEST/misc]   020-fix-superblock-corruption
    [TEST/misc]   021-image-multi-devices
    [TEST/misc]   022-filesystem-du-on-empty-subvol
    [TEST/misc]   023-device-usage-with-missing-device
    [TEST/misc]   024-inspect-internal-rootid
    [TEST/misc]   025-zstd-compression
    [TEST/misc]   026-image-non-printable-chars
    [TEST/misc]   027-subvol-list-deleted-toplevel
    [TEST/misc]   028-superblock-recover
    [TEST/misc]   029-send-p-different-mountpoints
    [TEST/misc]   030-missing-device-image
    [NOTRUN] unable to create v1 space cache
    [TEST/misc]   031-qgroup-parent-child-relation
    [TEST/misc]   032-bad-item-ptr
    [TEST/misc]   033-filename-length-limit
    [TEST/misc]   034-metadata-uuid
    [NOTRUN] btrfs must be a module
    [TEST/misc]   035-receive-common-mount-point-prefix
    [NOTRUN] fix not available
    [TEST/misc]   036-receive-dump-invalid-stream
    [TEST/misc]   037-fi-show-on-new-file
    [TEST/misc]   038-backup-root-corruption
    [TEST/misc]   039-receive-clone-from-current-subvolume
    [TEST/misc]   040-subvolume-delete-default
    [TEST/misc]   041-subvolume-delete-during-send
    [TEST/misc]   042-inspect-internal-logical-resolve
    [TEST/misc]   043-subvolume-set-default-toplevel
    [TEST/misc]   045-receive-check-mount-type
    [TEST/misc]   046-seed-multi-mount
    [TEST/misc]   047-raid5-convert
    [TEST/misc]   048-image-restore-mount
    [TEST/misc]   049-btrfstune-transid-mismatch
    [TEST/misc]   050-receive-prop-ro-to-rw
    [TEST/misc]   051-warning-rw-subvol-received-uuid
    [TEST/misc]   052-seed-dirty-log
    [TEST]   fuzz-tests.sh
    [TEST/fuzz]   001-simple-check-unmounted
    [TEST/fuzz]   002-simple-image
    [TEST/fuzz]   003-multi-check-unmounted
    [TEST/fuzz]   004-simple-dump-tree
    [TEST/fuzz]   005-simple-dump-super
    [TEST/fuzz]   006-simple-tree-stats
    [TEST/fuzz]   007-simple-super-recover
    [TEST/fuzz]   008-simple-chunk-recover
    [TEST/fuzz]   009-simple-zero-log
