### PR TITLE
Pwx 44553 rhel9.6 5.14.0 570

### DIFF
--- a/compression.c
+++ b/compression.c
@@ -559,7 +559,7 @@ blk_status_t btrfs_submit_compressed_write(struct btrfs_inode *inode, u64 start,
 				goto finish_cb;
 			}
 			if (blkcg_css)
-				bio->bi_opf |= REQ_CGROUP_PUNT;
+				bio->bi_opf |= REQ_BTRFS_CGROUP_PUNT;
 		}
 		/*
 		 * We should never reach next_stripe_start start as we will

--- a/ctree.h
+++ b/ctree.h
@@ -3303,7 +3303,7 @@ int btrfs_set_extent_delalloc(struct btrfs_inode *inode, u64 start, u64 end,
 int btrfs_create_subvol_root(struct btrfs_trans_handle *trans,
 			     struct btrfs_root *new_root,
 			     struct btrfs_root *parent_root,
-			     struct user_namespace *mnt_userns);
+			     struct mnt_idmap *idmap);
  void btrfs_set_delalloc_extent(struct inode *inode, struct extent_state *state,
 			       unsigned *bits);
 void btrfs_clear_delalloc_extent(struct inode *inode,
@@ -3378,7 +3378,7 @@ void btrfs_update_inode_bytes(struct btrfs_inode *inode,
 long btrfs_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 long btrfs_compat_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 int btrfs_fileattr_get(struct dentry *dentry, struct fileattr *fa);
-int btrfs_fileattr_set(struct user_namespace *mnt_userns,
+int btrfs_fileattr_set(struct mnt_idmap *idmap,
 		       struct dentry *dentry, struct fileattr *fa);
 int btrfs_ioctl_get_supported_features(void __user *arg);
 void btrfs_sync_inode_flags_to_i_flags(struct inode *inode);

--- a/disk-io.c
+++ b/disk-io.c
@@ -830,10 +830,10 @@ static void run_one_async_done(struct btrfs_work *work)
 
 	/*
 	 * All of the bios that pass through here are from async helpers.
-	 * Use REQ_CGROUP_PUNT to issue them from the owning cgroup's context.
-	 * This changes nothing when cgroups aren't in use.
+	 * Use REQ_BTRFS_CGROUP_PUNT to issue them from the owning cgroup's
+	 * context. This changes nothing when cgroups aren't in use.
 	 */
-	async->bio->bi_opf |= REQ_CGROUP_PUNT;
+	async->bio->bi_opf |= REQ_BTRFS_CGROUP_PUNT;
 	ret = btrfs_map_bio(btrfs_sb(inode->i_sb), async->bio, async->mirror_num);
 	if (ret) {
 		async->bio->bi_status = ret;

--- a/disk-io.c
+++ b/disk-io.c
@@ -4273,8 +4273,7 @@ static void write_dev_flush(struct btrfs_device *device)
 	 * of simplicity, since this is a debug tool and not meant for use in
 	 * non-debug builds.
 	 */
-	struct request_queue *q = bdev_get_queue(device->bdev);
-	if (!test_bit(QUEUE_FLAG_WC, &q->queue_flags))
+	if (!bdev_write_cache(device->bdev))
 		return;
 #endif
 

--- a/disk-io.h
+++ b/disk-io.h
@@ -17,6 +17,8 @@
  */
 #define BTRFS_BDEV_BLOCKSIZE	(4096)
 
+#define REQ_BTRFS_CGROUP_PUNT			REQ_FS_PRIVATE
+
 enum btrfs_wq_endio_type {
 	BTRFS_WQ_ENDIO_DATA,
 	BTRFS_WQ_ENDIO_METADATA,

--- a/extent_io.c
+++ b/extent_io.c
@@ -5213,8 +5213,6 @@ int extent_write_locked_range(struct inode *inode, u64 start, u64 end)
 		.sync_mode	= WB_SYNC_ALL,
 		.range_start	= start,
 		.range_end	= end + 1,
-		/* We're called from an async helper function */
-		.punt_to_cgroup	= 1,
 		.no_cgroup_owner = 1,
 	};
 

--- a/extent_io.c
+++ b/extent_io.c
@@ -244,13 +244,7 @@ int __init extent_io_init(void)
 			BIOSET_NEED_BVECS))
 		goto free_buffer_cache;
 
-	if (bioset_integrity_create(&btrfs_bioset, BIO_POOL_SIZE))
-		goto free_bioset;
-
 	return 0;
-
-free_bioset:
-	bioset_exit(&btrfs_bioset);
 
 free_buffer_cache:
 	kmem_cache_destroy(extent_buffer_cache);

--- a/extent_io.c
+++ b/extent_io.c
@@ -1897,7 +1897,7 @@ unsigned find_get_pages_contig(struct address_space *mapping, pgoff_t index,
 		if (xa_is_value(folio))
 			break;
 
-		if (!folio_try_get_rcu(folio))
+		if (!folio_try_get(folio))
 			goto retry;
 
 		if (unlikely(folio != xas_reload(&xas)))

--- a/extent_io.c
+++ b/extent_io.c
@@ -4892,14 +4892,14 @@ int btree_write_cache_pages(struct address_space *mapping,
 	int ret = 0;
 	int done = 0;
 	int nr_to_write_done = 0;
-	struct pagevec pvec;
-	int nr_pages;
+	struct folio_batch fbatch;
+	unsigned int nr_folios;
 	pgoff_t index;
 	pgoff_t end;		/* Inclusive */
 	int scanned = 0;
 	xa_mark_t tag;
 
-	pagevec_init(&pvec);
+	folio_batch_init(&fbatch);
 	if (wbc->range_cyclic) {
 		index = mapping->writeback_index; /* Start from prev offset */
 		end = -1;
@@ -4922,14 +4922,14 @@ retry:
 	if (wbc->sync_mode == WB_SYNC_ALL)
 		tag_pages_for_writeback(mapping, index, end);
 	while (!done && !nr_to_write_done && (index <= end) &&
-	       (nr_pages = pagevec_lookup_range_tag(&pvec, mapping, &index, end,
-			tag))) {
+	       (nr_folios = filemap_get_folios_tag(mapping, &index, end,
+						tag, &fbatch))) {
 		unsigned i;
 
-		for (i = 0; i < nr_pages; i++) {
-			struct page *page = pvec.pages[i];
+		for (i = 0; i < nr_folios; i++) {
+			struct folio *folio = fbatch.folios[i];
 
-			ret = submit_eb_page(page, wbc, &epd, &eb_context);
+			ret = submit_eb_page(&folio->page, wbc, &epd, &eb_context);
 			if (ret == 0)
 				continue;
 			if (ret < 0) {
@@ -4944,7 +4944,7 @@ retry:
 			 */
 			nr_to_write_done = wbc->nr_to_write <= 0;
 		}
-		pagevec_release(&pvec);
+		folio_batch_release(&fbatch);
 		cond_resched();
 	}
 	if (!scanned && !done) {
@@ -5021,8 +5021,8 @@ static int extent_write_cache_pages(struct address_space *mapping,
 	int ret = 0;
 	int done = 0;
 	int nr_to_write_done = 0;
-	struct pagevec pvec;
-	int nr_pages;
+	struct folio_batch fbatch;
+	unsigned int nr_folios;
 	pgoff_t index;
 	pgoff_t end;		/* Inclusive */
 	pgoff_t done_index;
@@ -5042,7 +5042,7 @@ static int extent_write_cache_pages(struct address_space *mapping,
 	if (!igrab(inode))
 		return 0;
 
-	pagevec_init(&pvec);
+	folio_batch_init(&fbatch);
 	if (wbc->range_cyclic) {
 		index = mapping->writeback_index; /* Start from prev offset */
 		end = -1;
@@ -5080,14 +5080,14 @@ retry:
 		tag_pages_for_writeback(mapping, index, end);
 	done_index = index;
 	while (!done && !nr_to_write_done && (index <= end) &&
-			(nr_pages = pagevec_lookup_range_tag(&pvec, mapping,
-						&index, end, tag))) {
+			(nr_folios = filemap_get_folios_tag(mapping, &index,
+							end, tag, &fbatch))) {
 		unsigned i;
 
-		for (i = 0; i < nr_pages; i++) {
-			struct page *page = pvec.pages[i];
+		for (i = 0; i < nr_folios; i++) {
+			struct folio *folio = fbatch.folios[i];
 
-			done_index = page->index + 1;
+			done_index = folio->index + folio_nr_pages(folio);
 			/*
 			 * At this point we hold neither the i_pages lock nor
 			 * the page lock: the page may be truncated or
@@ -5095,32 +5095,32 @@ retry:
 			 * or even swizzled back from swapper_space to
 			 * tmpfs file mapping
 			 */
-			if (!trylock_page(page)) {
+			if (!folio_trylock(folio)) {
 				ret = flush_write_bio(epd);
 				BUG_ON(ret < 0);
-				lock_page(page);
+				folio_lock(folio);
 			}
 
-			if (unlikely(page->mapping != mapping)) {
-				unlock_page(page);
+			if (unlikely(folio->mapping != mapping)) {
+				folio_unlock(folio);
 				continue;
 			}
 
 			if (wbc->sync_mode != WB_SYNC_NONE) {
-				if (PageWriteback(page)) {
+				if (folio_test_writeback(folio)) {
 					ret = flush_write_bio(epd);
 					BUG_ON(ret < 0);
 				}
-				wait_on_page_writeback(page);
+				folio_wait_writeback(folio);
 			}
 
-			if (PageWriteback(page) ||
-			    !clear_page_dirty_for_io(page)) {
-				unlock_page(page);
+                        if (folio_test_writeback(folio) ||
+                            !folio_clear_dirty_for_io(folio)) {
+                                folio_unlock(folio);
 				continue;
 			}
 
-			ret = __extent_writepage(page, wbc, epd);
+			ret = __extent_writepage(&folio->page, wbc, epd);
 			if (ret < 0) {
 				done = 1;
 				break;
@@ -5133,7 +5133,7 @@ retry:
 			 */
 			nr_to_write_done = wbc->nr_to_write <= 0;
 		}
-		pagevec_release(&pvec);
+		folio_batch_release(&fbatch);
 		cond_resched();
 	}
 	if (!scanned && !done) {

--- a/extent_io.c
+++ b/extent_io.c
@@ -7529,3 +7529,33 @@ void btrfs_readahead_node_child(struct extent_buffer *node, int slot)
 				   btrfs_node_ptr_generation(node, slot),
 				   btrfs_header_level(node) - 1);
 }
+
+/**
+ * folio_account_redirty - Manually account for redirtying a page.
+ * @folio: The folio which is being redirtied.
+ *
+ * Most filesystems should call folio_redirty_for_writepage() instead
+ * of this fuction.  If your filesystem is doing writeback outside the
+ * context of a writeback_control(), it can call this when redirtying
+ * a folio, to de-account the dirty counters (NR_DIRTIED, WB_DIRTIED,
+ * tsk->nr_dirtied), so that they match the written counters (NR_WRITTEN,
+ * WB_WRITTEN) in long term. The mismatches will lead to systematic errors
+ * in balanced_dirty_ratelimit and the dirty pages position control.
+ */
+void folio_account_redirty(struct folio *folio)
+{
+       struct address_space *mapping = folio->mapping;
+
+       if (mapping && mapping_can_writeback(mapping)) {
+               struct inode *inode = mapping->host;
+               struct bdi_writeback *wb;
+               struct wb_lock_cookie cookie = {};
+               long nr = folio_nr_pages(folio);
+
+               wb = unlocked_inode_to_wb_begin(inode, &cookie);
+               current->nr_dirtied -= nr;
+               node_stat_mod_folio(folio, NR_DIRTIED, -nr);
+               wb_stat_mod(wb, WB_DIRTIED, -nr);
+               unlocked_inode_to_wb_end(inode, &cookie);
+       }
+}

--- a/extent_io.h
+++ b/extent_io.h
@@ -308,6 +308,12 @@ int btrfs_repair_one_sector(struct inode *inode,
 			    u64 start, int failed_mirror,
 			    submit_bio_hook_t *submit_bio_hook);
 
+void folio_account_redirty(struct folio *folio);
+static inline void account_page_redirty(struct page *page)
+{
+       folio_account_redirty(page_folio(page));
+}
+
 #ifdef CONFIG_BTRFS_FS_RUN_SANITY_TESTS
 bool find_lock_delalloc_range(struct inode *inode,
 			     struct page *locked_page, u64 *start,

--- a/inode.c
+++ b/inode.c
@@ -5041,7 +5041,7 @@ static int btrfs_setsize(struct inode *inode, struct iattr *attr)
 	return ret;
 }
 
-static int btrfs_setattr(struct user_namespace *mnt_userns, struct dentry *dentry,
+static int btrfs_setattr(struct mnt_idmap *idmap, struct dentry *dentry,
 			 struct iattr *attr)
 {
 	struct inode *inode = d_inode(dentry);
@@ -5051,7 +5051,7 @@ static int btrfs_setattr(struct user_namespace *mnt_userns, struct dentry *dentr
 	if (btrfs_root_readonly(root))
 		return -EROFS;
 
-	err = setattr_prepare(mnt_userns, dentry, attr);
+	err = setattr_prepare(idmap, dentry, attr);
 	if (err)
 		return err;
 
@@ -5062,12 +5062,12 @@ static int btrfs_setattr(struct user_namespace *mnt_userns, struct dentry *dentr
 	}
 
 	if (attr->ia_valid) {
-		setattr_copy(mnt_userns, inode, attr);
+		setattr_copy(idmap, inode, attr);
 		inode_inc_iversion(inode);
 		err = btrfs_dirty_inode(inode);
 
 		if (!err && attr->ia_valid & ATTR_MODE)
-			err = posix_acl_chmod(mnt_userns, inode, inode->i_mode);
+			err = posix_acl_chmod(idmap, dentry, inode->i_mode);
 	}
 
 	return err;
@@ -6086,7 +6086,7 @@ static void btrfs_inherit_iflags(struct inode *inode, struct inode *dir)
 
 static struct inode *btrfs_new_inode(struct btrfs_trans_handle *trans,
 				     struct btrfs_root *root,
-				     struct user_namespace *mnt_userns,
+				     struct mnt_idmap *idmap,
 				     struct inode *dir,
 				     const char *name, int name_len,
 				     u64 ref_objectid, u64 objectid,
@@ -6200,7 +6200,7 @@ static struct inode *btrfs_new_inode(struct btrfs_trans_handle *trans,
 	if (ret != 0)
 		goto fail_unlock;
 
-	inode_init_owner(mnt_userns, inode, dir, mode);
+	inode_init_owner(idmap, inode, dir, mode);
 	inode_set_bytes(inode, 0);
 
 	inode->i_mtime = current_time(inode);
@@ -6361,7 +6361,7 @@ static int btrfs_add_nondir(struct btrfs_trans_handle *trans,
 	return err;
 }
 
-static int btrfs_mknod(struct user_namespace *mnt_userns, struct inode *dir,
+static int btrfs_mknod(struct mnt_idmap *idmap, struct inode *dir,
 		       struct dentry *dentry, umode_t mode, dev_t rdev)
 {
 	struct btrfs_fs_info *fs_info = btrfs_sb(dir->i_sb);
@@ -6385,7 +6385,7 @@ static int btrfs_mknod(struct user_namespace *mnt_userns, struct inode *dir,
 	if (err)
 		goto out_unlock;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir,
+	inode = btrfs_new_inode(trans, root, idmap, dir,
 			dentry->d_name.name, dentry->d_name.len,
 			btrfs_ino(BTRFS_I(dir)), objectid, mode, &index);
 	if (IS_ERR(inode)) {
@@ -6425,7 +6425,7 @@ out_unlock:
 	return err;
 }
 
-static int btrfs_create(struct user_namespace *mnt_userns, struct inode *dir,
+static int btrfs_create(struct mnt_idmap *idmap, struct inode *dir,
 			struct dentry *dentry, umode_t mode, bool excl)
 {
 	struct btrfs_fs_info *fs_info = btrfs_sb(dir->i_sb);
@@ -6449,7 +6449,7 @@ static int btrfs_create(struct user_namespace *mnt_userns, struct inode *dir,
 	if (err)
 		goto out_unlock;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir,
+        inode = btrfs_new_inode(trans, root, idmap, dir,
 			dentry->d_name.name, dentry->d_name.len,
 			btrfs_ino(BTRFS_I(dir)), objectid, mode, &index);
 	if (IS_ERR(inode)) {
@@ -6570,7 +6570,7 @@ fail:
 	return err;
 }
 
-static int btrfs_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
+static int btrfs_mkdir(struct mnt_idmap *idmap, struct inode *dir,
 		       struct dentry *dentry, umode_t mode)
 {
 	struct btrfs_fs_info *fs_info = btrfs_sb(dir->i_sb);
@@ -6594,7 +6594,7 @@ static int btrfs_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
 	if (err)
 		goto out_fail;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir,
+        inode = btrfs_new_inode(trans, root, idmap, dir,
 			dentry->d_name.name, dentry->d_name.len,
 			btrfs_ino(BTRFS_I(dir)), objectid,
 			S_IFDIR | mode, &index);
@@ -8799,7 +8799,7 @@ out:
 int btrfs_create_subvol_root(struct btrfs_trans_handle *trans,
 			     struct btrfs_root *new_root,
 			     struct btrfs_root *parent_root,
-			     struct user_namespace *mnt_userns)
+			     struct mnt_idmap *idmap)
 {
 	struct inode *inode;
 	int err;
@@ -8810,7 +8810,7 @@ int btrfs_create_subvol_root(struct btrfs_trans_handle *trans,
 	if (err < 0)
 		return err;
 
-	inode = btrfs_new_inode(trans, new_root, mnt_userns, NULL, "..", 2,
+	inode = btrfs_new_inode(trans, new_root, idmap, NULL, "..", 2,
 				ino, ino,
 				S_IFDIR | (~current_umask() & S_IRWXUGO),
 				&index);
@@ -9030,7 +9030,7 @@ fail:
 	return -ENOMEM;
 }
 
-static int btrfs_getattr(struct user_namespace *mnt_userns,
+static int btrfs_getattr(struct mnt_idmap *idmap,
 			 const struct path *path, struct kstat *stat,
 			 u32 request_mask, unsigned int flags)
 {
@@ -9060,7 +9060,7 @@ static int btrfs_getattr(struct user_namespace *mnt_userns,
 				  STATX_ATTR_IMMUTABLE |
 				  STATX_ATTR_NODUMP);
 
-	generic_fillattr(mnt_userns, inode, stat);
+	generic_fillattr(idmap, inode, stat);
 	stat->dev = BTRFS_I(inode)->root->anon_dev;
 
 	spin_lock(&BTRFS_I(inode)->lock);
@@ -9286,7 +9286,7 @@ out_notrans:
 
 static int btrfs_whiteout_for_rename(struct btrfs_trans_handle *trans,
 				     struct btrfs_root *root,
-				     struct user_namespace *mnt_userns,
+				     struct mnt_idmap *idmap,
 				     struct inode *dir,
 				     struct dentry *dentry)
 {
@@ -9299,7 +9299,7 @@ static int btrfs_whiteout_for_rename(struct btrfs_trans_handle *trans,
 	if (ret)
 		return ret;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir,
+        inode = btrfs_new_inode(trans, root, idmap, dir,
 				dentry->d_name.name,
 				dentry->d_name.len,
 				btrfs_ino(BTRFS_I(dir)),
@@ -9336,7 +9336,7 @@ out:
 	return ret;
 }
 
-static int btrfs_rename(struct user_namespace *mnt_userns,
+static int btrfs_rename(struct mnt_idmap *idmap,
 			struct inode *old_dir, struct dentry *old_dentry,
 			struct inode *new_dir, struct dentry *new_dentry,
 			unsigned int flags)
@@ -9508,7 +9508,7 @@ static int btrfs_rename(struct user_namespace *mnt_userns,
 				   rename_ctx.index, new_dentry->d_parent);
 
 	if (flags & RENAME_WHITEOUT) {
-		ret = btrfs_whiteout_for_rename(trans, root, mnt_userns,
+		ret = btrfs_whiteout_for_rename(trans, root, idmap,
 						old_dir, old_dentry);
 
 		if (ret) {
@@ -9526,7 +9526,7 @@ out_notrans:
 	return ret;
 }
 
-static int btrfs_rename2(struct user_namespace *mnt_userns, struct inode *old_dir,
+static int btrfs_rename2(struct mnt_idmap *idmap, struct inode *old_dir,
 			 struct dentry *old_dentry, struct inode *new_dir,
 			 struct dentry *new_dentry, unsigned int flags)
 {
@@ -9537,7 +9537,7 @@ static int btrfs_rename2(struct user_namespace *mnt_userns, struct inode *old_di
 		return btrfs_rename_exchange(old_dir, old_dentry, new_dir,
 					  new_dentry);
 
-	return btrfs_rename(mnt_userns, old_dir, old_dentry, new_dir,
+	return btrfs_rename(idmap, old_dir, old_dentry, new_dir,
 			    new_dentry, flags);
 }
 
@@ -9733,7 +9733,7 @@ out:
 	return ret;
 }
 
-static int btrfs_symlink(struct user_namespace *mnt_userns, struct inode *dir,
+static int btrfs_symlink(struct mnt_idmap *idmap, struct inode *dir,
 			 struct dentry *dentry, const char *symname)
 {
 	struct btrfs_fs_info *fs_info = btrfs_sb(dir->i_sb);
@@ -9770,7 +9770,7 @@ static int btrfs_symlink(struct user_namespace *mnt_userns, struct inode *dir,
 	if (err)
 		goto out_unlock;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir,
+        inode = btrfs_new_inode(trans, root, idmap, dir,
 				dentry->d_name.name, dentry->d_name.len,
 				btrfs_ino(BTRFS_I(dir)), objectid,
 				S_IFLNK | S_IRWXUGO, &index);
@@ -10078,7 +10078,7 @@ int btrfs_prealloc_file_range_trans(struct inode *inode,
 					   min_size, actual_len, alloc_hint, trans);
 }
 
-static int btrfs_permission(struct user_namespace *mnt_userns,
+static int btrfs_permission(struct mnt_idmap *idmap,
 			    struct inode *inode, int mask)
 {
 	struct btrfs_root *root = BTRFS_I(inode)->root;
@@ -10091,10 +10091,10 @@ static int btrfs_permission(struct user_namespace *mnt_userns,
 		if (BTRFS_I(inode)->flags & BTRFS_INODE_READONLY)
 			return -EACCES;
 	}
-	return generic_permission(mnt_userns, inode, mask);
+	return generic_permission(idmap, inode, mask);
 }
 
-static int btrfs_tmpfile(struct user_namespace *mnt_userns, struct inode *dir,
+static int btrfs_tmpfile(struct mnt_idmap *idmap, struct inode *dir,
 			 struct file *dentry, umode_t mode)
 			 // JAR struct dentry *dentry, umode_t mode)
 {
@@ -10117,7 +10117,7 @@ static int btrfs_tmpfile(struct user_namespace *mnt_userns, struct inode *dir,
 	if (ret)
 		goto out;
 
-	inode = btrfs_new_inode(trans, root, mnt_userns, dir, NULL, 0,
+        inode = btrfs_new_inode(trans, root, idmap, dir, NULL, 0,
 			btrfs_ino(BTRFS_I(dir)), objectid, mode, &index);
 	if (IS_ERR(inode)) {
 		ret = PTR_ERR(inode);

--- a/ioctl.c
+++ b/ioctl.c
@@ -5409,7 +5409,7 @@ static int btrfs_ioctl_encoded_write(struct file *file, void __user *argp, bool 
 		goto out_end_write;
 
 	init_sync_kiocb(&kiocb, file);
-	ret = kiocb_set_rw_flags(&kiocb, 0);
+	ret = kiocb_set_rw_flags(&kiocb, 0, WRITE);
 	if (ret)
 		goto out_end_write;
 	kiocb.ki_pos = pos;

--- a/ioctl.c
+++ b/ioctl.c
@@ -232,7 +232,7 @@ int btrfs_fileattr_get(struct dentry *dentry, struct fileattr *fa)
 	return 0;
 }
 
-int btrfs_fileattr_set(struct user_namespace *mnt_userns,
+int btrfs_fileattr_set(struct mnt_idmap *idmap,
 		       struct dentry *dentry, struct fileattr *fa)
 {
 	struct inode *inode = d_inode(dentry);
@@ -545,7 +545,7 @@ int __pure btrfs_is_empty_uuid(u8 *uuid)
 	return 1;
 }
 
-static noinline int create_subvol(struct user_namespace *mnt_userns,
+static noinline int create_subvol(struct mnt_idmap *idmap,
 				  struct inode *dir, struct dentry *dentry,
 				  const char *name, int namelen,
 				  struct btrfs_qgroup_inherit *inherit)
@@ -692,7 +692,7 @@ static noinline int create_subvol(struct user_namespace *mnt_userns,
 		goto fail;
 	}
 
-	ret = btrfs_create_subvol_root(trans, new_root, root, mnt_userns);
+	ret = btrfs_create_subvol_root(trans, new_root, root, idmap);
 	btrfs_put_root(new_root);
 	if (ret) {
 		/* We potentially lose an unused inode item here */
@@ -889,7 +889,7 @@ free_pending:
  *     nfs_async_unlink().
  */
 
-static int btrfs_may_delete(struct user_namespace *mnt_userns,
+static int btrfs_may_delete(struct mnt_idmap *idmap,
 			    struct inode *dir, struct dentry *victim, int isdir)
 {
 	int error;
@@ -900,12 +900,12 @@ static int btrfs_may_delete(struct user_namespace *mnt_userns,
 	BUG_ON(d_inode(victim->d_parent) != dir);
 	audit_inode_child(dir, victim, AUDIT_TYPE_CHILD_DELETE);
 
-	error = inode_permission(mnt_userns, dir, MAY_WRITE | MAY_EXEC);
+	error = inode_permission(idmap, dir, MAY_WRITE | MAY_EXEC);
 	if (error)
 		return error;
 	if (IS_APPEND(dir))
 		return -EPERM;
-	if (check_sticky(mnt_userns, dir, d_inode(victim)) ||
+	if (check_sticky(idmap, dir, d_inode(victim)) ||
 	    IS_APPEND(d_inode(victim)) || IS_IMMUTABLE(d_inode(victim)) ||
 	    IS_SWAPFILE(d_inode(victim)))
 		return -EPERM;
@@ -924,16 +924,16 @@ static int btrfs_may_delete(struct user_namespace *mnt_userns,
 }
 
 /* copy of may_create in fs/namei.c() */
-static inline int btrfs_may_create(struct user_namespace *mnt_userns,
+static inline int btrfs_may_create(struct mnt_idmap *idmap,
 				   struct inode *dir, struct dentry *child)
 {
 	if (d_really_is_positive(child))
 		return -EEXIST;
 	if (IS_DEADDIR(dir))
 		return -ENOENT;
-	if (!fsuidgid_has_mapping(dir->i_sb, mnt_userns))
+	if (!fsuidgid_has_mapping(dir->i_sb, idmap))
 		return -EOVERFLOW;
-	return inode_permission(mnt_userns, dir, MAY_WRITE | MAY_EXEC);
+	return inode_permission(idmap, dir, MAY_WRITE | MAY_EXEC);
 }
 
 /*
@@ -942,7 +942,7 @@ static inline int btrfs_may_create(struct user_namespace *mnt_userns,
  * inside this filesystem so it's quite a bit simpler.
  */
 static noinline int btrfs_mksubvol(const struct path *parent,
-				   struct user_namespace *mnt_userns,
+				   struct mnt_idmap *idmap,
 				   const char *name, int namelen,
 				   struct btrfs_root *snap_src,
 				   bool readonly,
@@ -962,7 +962,7 @@ static noinline int btrfs_mksubvol(const struct path *parent,
 	if (IS_ERR(dentry))
 		goto out_unlock;
 
-	error = btrfs_may_create(mnt_userns, dir, dentry);
+	error = btrfs_may_create(idmap, dir, dentry);
 	if (error)
 		goto out_dput;
 
@@ -984,7 +984,7 @@ static noinline int btrfs_mksubvol(const struct path *parent,
 	if (snap_src)
 		error = create_snapshot(snap_src, dir, dentry, readonly, inherit);
 	else
-		error = create_subvol(mnt_userns, dir, dentry, name, namelen, inherit);
+		error = create_subvol(idmap, dir, dentry, name, namelen, inherit);
 
 	if (!error)
 		fsnotify_mkdir(dir, dentry);
@@ -998,7 +998,7 @@ out_unlock:
 }
 
 static noinline int btrfs_mksnapshot(const struct path *parent,
-				   struct user_namespace *mnt_userns,
+				   struct mnt_idmap *idmap,
 				   const char *name, int namelen,
 				   struct btrfs_root *root,
 				   bool readonly,
@@ -1028,7 +1028,7 @@ static noinline int btrfs_mksnapshot(const struct path *parent,
 
 	btrfs_wait_ordered_extents(root, U64_MAX, 0, (u64)-1);
 
-	ret = btrfs_mksubvol(parent, mnt_userns, name, namelen,
+	ret = btrfs_mksubvol(parent, idmap, name, namelen,
 			     root, readonly, inherit);
 out:
 	if (snapshot_force_cow)
@@ -2110,7 +2110,7 @@ out_drop:
 }
 
 static noinline int __btrfs_ioctl_snap_create(struct file *file,
-				struct user_namespace *mnt_userns,
+				struct mnt_idmap *idmap,
 				const char *name, unsigned long fd, int subvol,
 				bool readonly,
 				struct btrfs_qgroup_inherit *inherit)
@@ -2138,7 +2138,7 @@ static noinline int __btrfs_ioctl_snap_create(struct file *file,
 	}
 
 	if (subvol) {
-		ret = btrfs_mksubvol(&file->f_path, mnt_userns, name,
+		ret = btrfs_mksubvol(&file->f_path, idmap, name,
 				     namelen, NULL, readonly, inherit);
 	} else {
 		struct fd src = fdget(fd);
@@ -2153,14 +2153,14 @@ static noinline int __btrfs_ioctl_snap_create(struct file *file,
 			btrfs_info(BTRFS_I(file_inode(file))->root->fs_info,
 				   "Snapshot src from another FS");
 			ret = -EXDEV;
-		} else if (!inode_owner_or_capable(mnt_userns, src_inode)) {
+		} else if (!inode_owner_or_capable(idmap, src_inode)) {
 			/*
 			 * Subvolume creation is not restricted, but snapshots
 			 * are limited to own subvolumes only
 			 */
 			ret = -EPERM;
 		} else {
-			ret = btrfs_mksnapshot(&file->f_path, mnt_userns,
+			ret = btrfs_mksnapshot(&file->f_path, idmap,
 					       name, namelen,
 					       BTRFS_I(src_inode)->root,
 					       readonly, inherit);
@@ -2187,7 +2187,7 @@ static noinline int btrfs_ioctl_snap_create(struct file *file,
 		return PTR_ERR(vol_args);
 	vol_args->name[BTRFS_PATH_NAME_MAX] = '\0';
 
-	ret = __btrfs_ioctl_snap_create(file, file_mnt_user_ns(file),
+	ret = __btrfs_ioctl_snap_create(file, file_mnt_idmap(file),
 					vol_args->name, vol_args->fd, subvol,
 					false, NULL);
 
@@ -2247,7 +2247,7 @@ static noinline int btrfs_ioctl_snap_create_v2(struct file *file,
 		}
 	}
 
-	ret = __btrfs_ioctl_snap_create(file, file_mnt_user_ns(file),
+	ret = __btrfs_ioctl_snap_create(file, file_mnt_idmap(file),
 					vol_args->name, vol_args->fd, subvol,
 					readonly, inherit);
 	if (ret)
@@ -2292,7 +2292,7 @@ static noinline int btrfs_ioctl_subvol_setflags(struct file *file,
 	u64 flags;
 	int ret = 0;
 
-	if (!inode_owner_or_capable(file_mnt_user_ns(file), inode))
+	if (!inode_owner_or_capable(file_mnt_idmap(file), inode))
 		return -EPERM;
 
 	ret = mnt_want_write_file(file);
@@ -2738,7 +2738,7 @@ out:
 	return ret;
 }
 
-static int btrfs_search_path_in_tree_user(struct user_namespace *mnt_userns,
+static int btrfs_search_path_in_tree_user(struct mnt_idmap *idmap,
 				struct inode *inode,
 				struct btrfs_ioctl_ino_lookup_user_args *args)
 {
@@ -2830,7 +2830,7 @@ static int btrfs_search_path_in_tree_user(struct user_namespace *mnt_userns,
 				ret = PTR_ERR(temp_inode);
 				goto out_put;
 			}
-			ret = inode_permission(mnt_userns, temp_inode,
+			ret = inode_permission(idmap, temp_inode,
 					       MAY_READ | MAY_EXEC);
 			iput(temp_inode);
 			if (ret) {
@@ -2969,7 +2969,7 @@ static int btrfs_ioctl_ino_lookup_user(struct file *file, void __user *argp)
 		return -EACCES;
 	}
 
-	ret = btrfs_search_path_in_tree_user(file_mnt_user_ns(file), inode, args);
+	ret = btrfs_search_path_in_tree_user(file_mnt_idmap(file), inode, args);
 
 	if (ret == 0 && copy_to_user(argp, args, sizeof(*args)))
 		ret = -EFAULT;
@@ -3200,7 +3200,7 @@ static noinline int btrfs_ioctl_snap_destroy(struct file *file,
 	struct btrfs_root *dest = NULL;
 	struct btrfs_ioctl_vol_args *vol_args = NULL;
 	struct btrfs_ioctl_vol_args_v2 *vol_args2 = NULL;
-	struct user_namespace *mnt_userns = file_mnt_user_ns(file);
+	struct mnt_idmap *idmap = file_mnt_idmap(file);
 	char *subvol_name, *subvol_name_ptr = NULL;
 	int subvol_namelen;
 	int err = 0;
@@ -3293,7 +3293,7 @@ static noinline int btrfs_ioctl_snap_destroy(struct file *file,
 			 * anywhere in the filesystem the user wouldn't be able
 			 * to delete without an idmapped mount.
 			 */
-			if (old_dir != dir && mnt_userns != &init_user_ns) {
+			if (old_dir != dir && idmap != &nop_mnt_idmap) {
 				err = -EOPNOTSUPP;
 				goto free_parent;
 			}
@@ -3379,13 +3379,13 @@ static noinline int btrfs_ioctl_snap_destroy(struct file *file,
 		if (root == dest)
 			goto out_dput;
 
-		err = inode_permission(mnt_userns, inode, MAY_WRITE | MAY_EXEC);
+		err = inode_permission(idmap, inode, MAY_WRITE | MAY_EXEC);
 		if (err)
 			goto out_dput;
 	}
 
 	/* check if subvolume may be deleted by a user */
-	err = btrfs_may_delete(mnt_userns, dir, dentry, 1);
+	err = btrfs_may_delete(idmap, dir, dentry, 1);
 	if (err)
 		goto out_dput;
 
@@ -3448,7 +3448,7 @@ static int btrfs_ioctl_defrag(struct file *file, void __user *argp)
 		 * running and allows defrag on files open in read-only mode.
 		 */
 		if (!capable(CAP_SYS_ADMIN) &&
-		    inode_permission(&init_user_ns, inode, MAY_WRITE)) {
+		    inode_permission(&nop_mnt_idmap, inode, MAY_WRITE)) {
 			ret = -EPERM;
 			goto out;
 		}
@@ -4805,7 +4805,7 @@ static long btrfs_ioctl_quota_rescan_wait(struct btrfs_fs_info *fs_info,
 }
 
 static long _btrfs_ioctl_set_received_subvol(struct file *file,
-					    struct user_namespace *mnt_userns,
+					    struct mnt_idmap *idmap,
 					    struct btrfs_ioctl_received_subvol_args *sa)
 {
 	struct inode *inode = file_inode(file);
@@ -4817,7 +4817,7 @@ static long _btrfs_ioctl_set_received_subvol(struct file *file,
 	int ret = 0;
 	int received_uuid_changed;
 
-	if (!inode_owner_or_capable(mnt_userns, inode))
+	if (!inode_owner_or_capable(idmap, inode))
 		return -EPERM;
 
 	ret = mnt_want_write_file(file);
@@ -4922,7 +4922,7 @@ static long btrfs_ioctl_set_received_subvol_32(struct file *file,
 	args64->rtime.nsec = args32->rtime.nsec;
 	args64->flags = args32->flags;
 
-	ret = _btrfs_ioctl_set_received_subvol(file, file_mnt_user_ns(file), args64);
+	ret = _btrfs_ioctl_set_received_subvol(file, file_mnt_idmap(file), args64);
 	if (ret)
 		goto out;
 
@@ -4956,7 +4956,7 @@ static long btrfs_ioctl_set_received_subvol(struct file *file,
 	if (IS_ERR(sa))
 		return PTR_ERR(sa);
 
-	ret = _btrfs_ioctl_set_received_subvol(file, file_mnt_user_ns(file), sa);
+	ret = _btrfs_ioctl_set_received_subvol(file, file_mnt_idmap(file), sa);
 
 	if (ret)
 		goto out;

--- a/misc.h
+++ b/misc.h
@@ -10,7 +10,9 @@
 // JAR - added the below include
 #include <linux/fs.h>
 
+#ifndef in_range
 #define in_range(b, first, len) ((b) >= (first) && (b) < (first) + (len))
+#endif
 
 static inline void cond_wake_up(struct wait_queue_head *wq)
 {

--- a/tree-checker.c
+++ b/tree-checker.c
@@ -594,7 +594,7 @@ static int check_dir_item(struct extent_buffer *leaf,
 		 */
 		if (key->type == BTRFS_DIR_ITEM_KEY ||
 		    key->type == BTRFS_XATTR_ITEM_KEY) {
-			char namebuf[max(BTRFS_NAME_LEN, XATTR_NAME_MAX)];
+			char namebuf[MAX(BTRFS_NAME_LEN, XATTR_NAME_MAX)];
 
 			read_extent_buffer(leaf, namebuf,
 					(unsigned long)(di + 1), name_len);

--- a/xattr.c
+++ b/xattr.c
@@ -384,7 +384,7 @@ static int btrfs_xattr_handler_get(const struct xattr_handler *handler,
 }
 
 static int btrfs_xattr_handler_set(const struct xattr_handler *handler,
-				   struct user_namespace *mnt_userns,
+				   struct mnt_idmap *idmap,
 				   struct dentry *unused, struct inode *inode,
 				   const char *name, const void *buffer,
 				   size_t size, int flags)
@@ -394,7 +394,7 @@ static int btrfs_xattr_handler_set(const struct xattr_handler *handler,
 }
 
 static int btrfs_xattr_handler_set_prop(const struct xattr_handler *handler,
-					struct user_namespace *mnt_userns,
+					struct mnt_idmap *idmap,
 					struct dentry *unused, struct inode *inode,
 					const char *name, const void *value,
 					size_t size, int flags)

--- a/zoned.c
+++ b/zoned.c
@@ -782,8 +782,7 @@ static int sb_log_location(struct block_device *bdev, struct blk_zone *zones,
 			ASSERT(sb_zone_is_full(reset));
 
 			ret = blkdev_zone_mgmt(bdev, REQ_OP_ZONE_RESET,
-					       reset->start, reset->len,
-					       GFP_NOFS);
+					       reset->start, reset->len);
 			if (ret)
 				return ret;
 
@@ -933,7 +932,7 @@ int btrfs_advance_sb_log(struct btrfs_device *device, int mirror)
 
 				ret = blkdev_zone_mgmt(device->bdev,
 						REQ_OP_ZONE_FINISH, zone->start,
-						zone->len, GFP_NOFS);
+						zone->len);
 				if (ret)
 					return ret;
 			}
@@ -968,7 +967,7 @@ int btrfs_reset_sb_log_zones(struct block_device *bdev, int mirror)
 
 	return blkdev_zone_mgmt(bdev, REQ_OP_ZONE_RESET,
 				zone_start_sector(sb_zone, bdev),
-				zone_sectors * BTRFS_NR_SB_LOG_ZONES, GFP_NOFS);
+				zone_sectors * BTRFS_NR_SB_LOG_ZONES);
 }
 
 /**
@@ -1083,8 +1082,7 @@ int btrfs_reset_device_zone(struct btrfs_device *device, u64 physical,
 
 	*bytes = 0;
 	ret = blkdev_zone_mgmt(device->bdev, REQ_OP_ZONE_RESET,
-			       physical >> SECTOR_SHIFT, length >> SECTOR_SHIFT,
-			       GFP_NOFS);
+			       physical >> SECTOR_SHIFT, length >> SECTOR_SHIFT);
 	if (ret)
 		return ret;
 
@@ -1949,8 +1947,7 @@ int btrfs_zone_finish(struct btrfs_block_group *block_group)
 
 		ret = blkdev_zone_mgmt(device->bdev, REQ_OP_ZONE_FINISH,
 				       physical >> SECTOR_SHIFT,
-				       device->zone_info->zone_size >> SECTOR_SHIFT,
-				       GFP_NOFS);
+				       device->zone_info->zone_size >> SECTOR_SHIFT);
 
 		if (ret)
 			return ret;

--- a/zoned.c
+++ b/zoned.c
@@ -628,74 +628,49 @@ int btrfs_get_dev_zone(struct btrfs_device *device, u64 pos,
 	return 0;
 }
 
+static int btrfs_check_for_zoned_device(struct btrfs_fs_info *fs_info)
+{
+        struct btrfs_device *device;
+
+        list_for_each_entry(device, &fs_info->fs_devices->devices, dev_list) {
+                if (device->bdev && bdev_is_zoned(device->bdev)) {
+                        btrfs_err(fs_info,
+                                "zoned: mode not enabled but zoned device found: %pg",
+                                device->bdev);
+                        return -EINVAL;
+                }
+        }
+
+        return 0;
+}
+
 int btrfs_check_zoned_mode(struct btrfs_fs_info *fs_info)
 {
-	struct btrfs_fs_devices *fs_devices = fs_info->fs_devices;
 	struct btrfs_device *device;
-	u64 zoned_devices = 0;
-	u64 nr_devices = 0;
 	u64 zone_size = 0;
-	const bool incompat_zoned = btrfs_fs_incompat(fs_info, ZONED);
-	int ret = 0;
+	int ret;
 
-	/* Count zoned devices */
-	list_for_each_entry(device, &fs_devices->devices, dev_list) {
-		enum blk_zoned_model model;
+        /*
+         * Host-Managed devices can't be used without the ZONED flag.  With the
+         * ZONED all devices can be used, using zone emulation if required.
+         */
+        if (!btrfs_fs_incompat(fs_info, ZONED))
+                return btrfs_check_for_zoned_device(fs_info);
+
+        list_for_each_entry(device, &fs_info->fs_devices->devices, dev_list) {
+                struct btrfs_zoned_device_info *zone_info = device->zone_info;
 
 		if (!device->bdev)
 			continue;
 
-		model = bdev_zoned_model(device->bdev);
-		/*
-		 * A Host-Managed zoned device must be used as a zoned device.
-		 * A Host-Aware zoned device and a non-zoned devices can be
-		 * treated as a zoned device, if ZONED flag is enabled in the
-		 * superblock.
-		 */
-		if (model == BLK_ZONED_HM ||
-		    (model == BLK_ZONED_HA && incompat_zoned) ||
-		    (model == BLK_ZONED_NONE && incompat_zoned)) {
-			struct btrfs_zoned_device_info *zone_info;
-
-			zone_info = device->zone_info;
-			zoned_devices++;
-			if (!zone_size) {
-				zone_size = zone_info->zone_size;
-			} else if (zone_info->zone_size != zone_size) {
-				btrfs_err(fs_info,
+                if (!zone_size) {
+                        zone_size = zone_info->zone_size;
+                } else if (zone_info->zone_size != zone_size) {
+                        btrfs_err(fs_info,
 		"zoned: unequal block device zone sizes: have %llu found %llu",
-					  device->zone_info->zone_size,
-					  zone_size);
-				ret = -EINVAL;
-				goto out;
-			}
+                                  zone_info->zone_size, zone_size);
+                        return -EINVAL;
 		}
-		nr_devices++;
-	}
-
-	if (!zoned_devices && !incompat_zoned)
-		goto out;
-
-	if (!zoned_devices && incompat_zoned) {
-		/* No zoned block device found on ZONED filesystem */
-		btrfs_err(fs_info,
-			  "zoned: no zoned devices found on a zoned filesystem");
-		ret = -EINVAL;
-		goto out;
-	}
-
-	if (zoned_devices && !incompat_zoned) {
-		btrfs_err(fs_info,
-			  "zoned: mode not enabled but zoned device found");
-		ret = -EINVAL;
-		goto out;
-	}
-
-	if (zoned_devices != nr_devices) {
-		btrfs_err(fs_info,
-			  "zoned: cannot mix zoned and regular devices");
-		ret = -EINVAL;
-		goto out;
 	}
 
 	/*
@@ -707,14 +682,12 @@ int btrfs_check_zoned_mode(struct btrfs_fs_info *fs_info)
 		btrfs_err(fs_info,
 			  "zoned: zone size %llu not aligned to stripe %u",
 			  zone_size, BTRFS_STRIPE_LEN);
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	if (btrfs_fs_incompat(fs_info, MIXED_GROUPS)) {
 		btrfs_err(fs_info, "zoned: mixed block groups not supported");
-		ret = -EINVAL;
-		goto out;
+		return -EINVAL;
 	}
 
 	fs_info->zone_size = zone_size;
@@ -726,11 +699,10 @@ int btrfs_check_zoned_mode(struct btrfs_fs_info *fs_info)
 	 */
 	ret = btrfs_check_mountopts_zoned(fs_info);
 	if (ret)
-		goto out;
+		return ret;
 
 	btrfs_info(fs_info, "zoned mode enabled with zone size %llu", zone_size);
-out:
-	return ret;
+	return 0;
 }
 
 int btrfs_check_mountopts_zoned(struct btrfs_fs_info *info)

--- a/zoned.c
+++ b/zoned.c
@@ -563,26 +563,12 @@ int btrfs_get_dev_zone_info(struct btrfs_device *device, bool populate_cache)
 
 	kfree(zones);
 
-	switch (bdev_zoned_model(bdev)) {
-	case BLK_ZONED_HM:
+	if (bdev_is_zoned(bdev)) {
 		model = "host-managed zoned";
 		emulated = "";
-		break;
-	case BLK_ZONED_HA:
-		model = "host-aware zoned";
-		emulated = "";
-		break;
-	case BLK_ZONED_NONE:
+	} else {
 		model = "regular";
 		emulated = "emulated ";
-		break;
-	default:
-		/* Just in case */
-		btrfs_err_in_rcu(fs_info, "zoned: unsupported model %d on %s",
-				 bdev_zoned_model(bdev),
-				 rcu_str_deref(device->name));
-		ret = -EOPNOTSUPP;
-		goto out_free_zone_info;
 	}
 
 	btrfs_info_in_rcu(fs_info,
@@ -594,9 +580,7 @@ int btrfs_get_dev_zone_info(struct btrfs_device *device, bool populate_cache)
 
 out:
 	kfree(zones);
-out_free_zone_info:
 	btrfs_destroy_dev_zone_info(device);
-
 	return ret;
 }
 

--- a/zoned.h
+++ b/zoned.h
@@ -23,30 +23,6 @@
  * Note: This needs to be ordered from the least to the most severe
  * restrictions for the inheritance in blk_stack_limits() to work.
  */
-enum blk_zoned_model {
-	BLK_ZONED_NONE = 0,	/* Regular block device */
-	BLK_ZONED_HA,		/* Host-aware zoned block device */
-	BLK_ZONED_HM,		/* Host-managed zoned block device */
-};
-
-static inline enum blk_zoned_model
-blk_queue_zoned_model(struct request_queue *q)
-{
-	if (IS_ENABLED(CONFIG_BLK_DEV_ZONED))
-		return q->limits.zoned;
-	return BLK_ZONED_NONE;
-}
-
-static inline enum blk_zoned_model bdev_zoned_model(struct block_device *bdev)
-{
-	struct request_queue *q = bdev_get_queue(bdev);
-
-	if (q)
-		return blk_queue_zoned_model(q);
-
-	return BLK_ZONED_NONE;
-}
-
 struct btrfs_zoned_device_info {
 	/*
 	 * Number of zones, zone size and types of zones if bdev is a
@@ -331,7 +307,7 @@ static inline bool btrfs_check_device_zone_type(const struct btrfs_fs_info *fs_i
 	}
 
 	/* Do not allow Host Manged zoned device */
-	return bdev_zoned_model(bdev) != BLK_ZONED_HM;
+	return !bdev_is_zoned(bdev);
 }
 
 static inline bool btrfs_check_super_location(struct btrfs_device *device, u64 pos)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # PWX-44553

**Special notes for your reviewer**:

```
[root@ip-10-38-110-203 btrfs-progs]# make test 
  TEST     fsck-tests.sh
    [TEST/fsck]   001-bad-file-extent-bytenr
    [TEST/fsck]   002-bad-transid
    [TEST/fsck]   003-shift-offsets
    [TEST/fsck]   004-no-dir-index
    [TEST/fsck]   005-bad-item-offset
    [TEST/fsck]   006-bad-root-items
    [TEST/fsck]   007-bad-offset-snapshots
    [TEST/fsck]   008-bad-dir-index-name
    [TEST/fsck]   009-no-dir-item-or-index
    [TEST/fsck]   010-no-rootdir-inode-item
    [TEST/fsck]   011-no-inode-item
    [TEST/fsck]   012-leaf-corruption
    [TEST/fsck]   013-extent-tree-rebuild
    [TEST/fsck]   014-no-extent-info
    [TEST/fsck]   016-wrong-inode-nbytes
    [TEST/fsck]   017-missing-all-file-extent
    [TEST/fsck]   018-leaf-crossing-stripes
    [TEST/fsck]   019-non-skinny-false-alert
    [TEST/fsck]   020-extent-ref-cases
    [TEST/fsck]   021-partially-dropped-snapshot-case
    [TEST/fsck]   022-qgroup-rescan-halfway
    [TEST/fsck]   023-qgroup-stack-overflow
    [TEST/fsck]   024-clear-space-cache
    [TEST/fsck]   025-file-extents
    [TEST/fsck]   026-bad-dir-item-name
    [TEST/fsck]   027-bad-extent-inline-ref-type
    [TEST/fsck]   028-unaligned-super-dev-sizes
    [TEST/fsck]   029-valid-orphan-item
    [TEST/fsck]   030-reflinked-prealloc-extents
    [TEST/fsck]   031-metadatadump-check-data-csum
    [TEST/fsck]   032-corrupted-qgroup
    [TEST/fsck]   033-lowmem-collission-dir-items
    [TEST/fsck]   034-bad-inode-flags
    [TEST/fsck]   035-inline-bad-ram-bytes
    [TEST/fsck]   036-bad-dev-extents
    [TEST/fsck]   036-rescan-not-kicked-in
    [TEST/fsck]   037-freespacetree-repair
    [TEST/fsck]   038-missing-one-file-extent
    [TEST/fsck]   039-bad-inode-mode
    [TEST/fsck]   040-compressed-nodatasum
    [TEST/fsck]   041-invalid-root-generation
    [TEST/fsck]   042-half-dropped-inode
    [TEST/fsck]   043-bad-inode-generation
    [TEST/fsck]   044-invalid-extent-item-generation
    [TEST/fsck]   045-overlap-csum-item
    [TEST/fsck]   047-dev-bytes-used
    [TEST/fsck]   049-dir-hard-link
    [TEST/fsck]   050-invalid-block-group-used
    [TEST/fsck]   051-invalid-super-bytes-used
    [TEST/fsck]   052-init-csum-tree
    [TEST/fsck]   053-bad-metadata-level
    [TEST/fsck]   054-orphan-directory
    [TEST/fsck]   055-super-num-devs-mismatch
    [TEST/fsck]   056-raid56-false-alerts
    [TEST/fsck]   057-seed-false-alerts
    [TEST/fsck]   058-bad-free-space-tree-entry
    [TEST/fsck]   059-shrunk-device
    [TEST/fsck]   060-degraded-check
    [TEST/fsck]   061-out-of-order-inline-backref
    [TEST/fsck]   063-log-missing-csum
    [TEST/fsck]   064-deprecated-inode-cache
    [TEST/fsck]   065-valid-log-tree
  TEST     mkfs-tests.sh
    [TEST/mkfs]   001-basic-profiles
    [TEST/mkfs]   002-no-force-mixed-on-small-volume
    [TEST/mkfs]   003-mixed-with-wrong-nodesize
    [TEST/mkfs]   004-rootdir-keeps-size
    [TEST/mkfs]   005-long-device-name-for-ssd
    [TEST/mkfs]   006-partitioned-loopdev
    [TEST/mkfs]   007-mix-nodesize-sectorsize
    [TEST/mkfs]   008-sectorsize-nodesize-combination
    [TEST/mkfs]   009-special-files-for-rootdir
    [TEST/mkfs]   010-minimal-size
    [TEST/mkfs]   011-rootdir-create-file
    [TEST/mkfs]   012-rootdir-no-shrink
    [TEST/mkfs]   013-reserved-1M-for-single
    [TEST/mkfs]   014-rootdir-inline-extent
    [TEST/mkfs]   015-fstree-uuid-otime
    [TEST/mkfs]   016-rootdir-bad-symbolic-link
    [TEST/mkfs]   017-small-backing-size-thin-provision-device
    [TEST/mkfs]   018-multidevice-overflow
    [TEST/mkfs]   019-basic-checksums-mkfs
    [TEST/mkfs]   020-basic-checksums-mount
    [TEST/mkfs]   021-rfeatures-quota-rootdir
    [TEST/mkfs]   022-rootdir-size
    [TEST/mkfs]   023-free-space-tree
    [TEST/mkfs]   024-fst-bitmaps
    [TEST/mkfs]   025-zoned-parallel
    [NOTRUN] skip test
    [TEST/mkfs]   026-extent-tree-to-bgt
    [TEST/mkfs]   027-rootdir-inode
    [TEST/mkfs]   028-block-group-tree
    [TEST/mkfs]   029-raid-stripe-tree
    [NOTRUN] This test requires experimental build
    [TEST/mkfs]   030-zoned-rst
    [NOTRUN] This test requires experimental build
    [TEST/mkfs]   031-zoned-bgt
    [NOTRUN] skip test
    [TEST/mkfs]   032-zoned-reset
    [NOTRUN] skip test
    [TEST/mkfs]   033-zoned-reject-rst
    [NOTRUN] skip test
    [TEST/mkfs]   034-rootdir-extra-hard-links
    [TEST/mkfs]   035-rootdir-cross-mount
    [TEST/mkfs]   036-rootdir-subvol
    [TEST/mkfs]   037-basic-compression
    [TEST/mkfs]   038-inode-flags
  TEST     misc-tests.sh
    [TEST/misc]   001-btrfstune-features
    [TEST/misc]   002-uuid-rewrite
    [TEST/misc]   003-zero-log
    [TEST/misc]   004-shrink-fs
    [TEST/misc]   005-convert-progress-thread-crash
    [TEST/misc]   006-image-on-missing-device
    [TEST/misc]   007-subvolume-sync
    [TEST/misc]   008-leaf-crossing-stripes
    [TEST/misc]   009-subvolume-sync-must-wait
    [TEST/misc]   010-convert-delete-ext2-subvol
    [TEST/misc]   011-delete-missing-device
    [TEST/misc]   012-find-root-no-result
    [TEST/misc]   013-subvolume-sync-crash
    [TEST/misc]   014-filesystem-label
    [TEST/misc]   015-dump-super-garbage
    [TEST/misc]   016-send-clone-src
    [TEST/misc]   017-recv-stream-malformatted
    [TEST/misc]   018-recv-end-of-stream
    [TEST/misc]   019-receive-clones-on-mounted-subvol
    [TEST/misc]   020-fix-superblock-corruption
    [TEST/misc]   021-image-multi-devices
    [TEST/misc]   022-filesystem-du-on-empty-subvol
    [TEST/misc]   023-device-usage-with-missing-device
    [TEST/misc]   024-inspect-internal-rootid
    [TEST/misc]   025-zstd-compression
    [TEST/misc]   026-image-non-printable-chars
    [TEST/misc]   027-subvol-list-deleted-toplevel
    [TEST/misc]   028-superblock-recover
    [TEST/misc]   029-send-p-different-mountpoints
    [TEST/misc]   030-missing-device-image
    [TEST/misc]   031-qgroup-parent-child-relation
    [TEST/misc]   032-bad-item-ptr
    [TEST/misc]   033-filename-length-limit
    [TEST/misc]   034-metadata-uuid
    [TEST/misc]   035-receive-common-mount-point-prefix
    [NOTRUN] fix not available
    [TEST/misc]   036-receive-dump-invalid-stream
    [TEST/misc]   037-fi-show-on-new-file
    [TEST/misc]   038-backup-root-corruption
    [TEST/misc]   039-receive-clone-from-current-subvolume
    [TEST/misc]   040-subvolume-delete-default
    [TEST/misc]   041-subvolume-delete-during-send
    [TEST/misc]   042-inspect-internal-logical-resolve
    [TEST/misc]   043-subvolume-set-default-toplevel
    [TEST/misc]   045-receive-check-mount-type
    [TEST/misc]   046-seed-multi-mount
    [TEST/misc]   047-raid5-convert
    [TEST/misc]   048-image-restore-mount
    [TEST/misc]   049-btrfstune-transid-mismatch
    [TEST/misc]   050-receive-prop-ro-to-rw
    [TEST/misc]   051-warning-rw-subvol-received-uuid
    [TEST/misc]   052-seed-dirty-log
    [TEST/misc]   053-receive-write-encoded
    [NOTRUN] kernel does not support send stream >1
    [TEST/misc]   054-receive-dump-newlines
    [TEST/misc]   055-qgroup-clear-stale
    [TEST/misc]   057-btrfstune-free-space-tree
    [NOTRUN] ACL is not compiled in
    [TEST/misc]   058-replace-start-enqueue
    [TEST/misc]   059-qgroup-show-stale-qgroup-crash
    [TEST/misc]   060-ino-cache-clean
    [TEST/misc]   061-reverse-receive
    [TEST/misc]   062-fi-show-raw-dm-all-devices
    [TEST/misc]   063-btrfstune-zoned-bgt
    [NOTRUN] skip test
    [TEST/misc]   064-csum-conversion-basic
    [NOTRUN] This test requires experimental build
    [TEST/misc]   065-csum-conversion-inject
    [NOTRUN] This test requires experimental build
    [TEST/misc]   066-image-filename
    [TEST/misc]   067-btrfstune-simple-quota
    [NOTRUN] This test requires experimental build
    [TEST/misc]   068-subvol-delete-recursive-show-child
  TEST     cli-tests.sh
    [TEST/cli]   001-btrfs
    [TEST/cli]   002-balance-full-no-filters
    [TEST/cli]   003-fi-resize-args
    [TEST/cli]   004-send-parent-multi-subvol
    [TEST/cli]   005-qgroup-show
    [TEST/cli]   006-qgroup-show-sync
    [TEST/cli]   007-check-force
    [TEST/cli]   008-subvolume-get-set-default
    [TEST/cli]   009-btrfstune
    [TEST/cli]   010-subvol-show-qgroup
    [TEST/cli]   011-defrag-recursion
    [TEST/cli]   012-fi-du-recursion
    [TEST/cli]   013-subvolume-delete-by-id
    [TEST/cli]   014-multiple-profiles-warning
    [TEST/cli]   015-defrag-compress
    [TEST/cli]   016-btrfs-fi-usage
    [TEST/cli]   017-fi-show-missing
    [TEST/cli]   019-subvolume-create-parents
    [TEST/cli]   020-dry-run
    [TEST/cli]   021-subvolume-multiple-arguments
    [TEST/cli]   022-fi-du-suffixes
    [TEST/cli]   023-device-delete-force
    [TEST/cli]   024-scrub-limit
    [TEST/cli]   025-subvolume-create-failures
  TEST     fuzz-tests.sh
    [TEST/fuzz]   001-simple-check-unmounted
    [TEST/fuzz]   002-simple-image
    [TEST/fuzz]   003-multi-check-unmounted
    [TEST/fuzz]   004-simple-dump-tree
    [TEST/fuzz]   005-simple-dump-super
    [TEST/fuzz]   006-simple-tree-stats
    [TEST/fuzz]   007-simple-super-recover
    [TEST/fuzz]   008-simple-chunk-recover
    [TEST/fuzz]   009-simple-zero-log
  PY       libbtrfsutil
test_start_sync (test_filesystem.TestFilesystem) ... ok
test_sync (test_filesystem.TestFilesystem) ... ok
test_wait_sync (test_filesystem.TestFilesystem) ... ok
test_snapshot_inherit (test_qgroup.TestQgroup) ... ok
test_subvolume_inherit (test_qgroup.TestQgroup) ... ok
test_add_group (test_qgroup.TestQgroupInherit) ... ok
test_new (test_qgroup.TestQgroupInherit) ... ok
test_create_snapshot (test_subvolume.TestSubvolume) ... ok
test_create_subvolume (test_subvolume.TestSubvolume) ... ok
test_default_subvolume (test_subvolume.TestSubvolume) ... ok
test_delete_subvolume (test_subvolume.TestSubvolume) ... ok
test_deleted_subvolumes (test_subvolume.TestSubvolume) ... ok
test_is_subvolume (test_subvolume.TestSubvolume) ... ok
test_read_only (test_subvolume.TestSubvolume) ... ok
test_subvolume_id (test_subvolume.TestSubvolume) ... ok
test_subvolume_id_error (test_subvolume.TestSubvolume) ... ok
test_subvolume_info (test_subvolume.TestSubvolume) ... ok
test_subvolume_info_unprivileged (test_subvolume.TestSubvolume) ... ok
test_subvolume_iterator (test_subvolume.TestSubvolume) ... ok
test_subvolume_iterator_fd_unprivileged (test_subvolume.TestSubvolume) ... ok
test_subvolume_iterator_race (test_subvolume.TestSubvolume) ... ok
test_subvolume_iterator_race_unprivileged (test_subvolume.TestSubvolume) ... ok
test_subvolume_iterator_unprivileged (test_subvolume.TestSubvolume) ... ok
test_subvolume_path (test_subvolume.TestSubvolume) ... ok

----------------------------------------------------------------------
Ran 24 tests in 33.321s

OK
```
