### PR TITLE
BTRFS build for Rhel10.1 6.12.0 124.20.1 

### DIFF
--- a/compression.c
+++ b/compression.c
@@ -578,12 +578,11 @@ blk_status_t btrfs_submit_compressed_write(struct btrfs_inode *inode, u64 start,
 		real_size = min_t(u64, real_size, compressed_len - offset);
 		ASSERT(IS_ALIGNED(real_size, fs_info->sectorsize));
 
-		if (use_append)
-			added = bio_add_zone_append_page(bio, page, real_size,
-					offset_in_page(offset));
-		else
-			added = bio_add_page(bio, page, real_size,
-					offset_in_page(offset));
+		/*
+		 * RHEL 10.1 kernel 6.12: bio_add_zone_append_page() was removed.
+		 * bio_add_page() now handles all cases including REQ_OP_ZONE_APPEND.
+		 */
+		added = bio_add_page(bio, page, real_size, offset_in_page(offset));
 		/* Reached zoned boundary */
 		if (added == 0)
 			submit = true;

--- a/ctree.h
+++ b/ctree.h
@@ -3884,9 +3884,10 @@ static inline bool btrfs_is_data_reloc_root(const struct btrfs_root *root)
  *
  * Rename the Private2 accessors to Ordered, to improve readability.
  */
-#define PageOrdered(page)		PagePrivate2(page)
-#define SetPageOrdered(page)		SetPagePrivate2(page)
-#define ClearPageOrdered(page)		ClearPagePrivate2(page)
+/* RHEL 10.1 kernel 6.12: Use folio-based API for Private2 flag */
+#define PageOrdered(page)		folio_test_private_2(page_folio(page))
+#define SetPageOrdered(page)		folio_set_private_2(page_folio(page))
+#define ClearPageOrdered(page)		folio_clear_private_2(page_folio(page))
 #define folio_test_ordered(folio)	folio_test_private_2(folio)
 #define folio_set_ordered(folio)	folio_set_private_2(folio)
 #define folio_clear_ordered(folio)	folio_clear_private_2(folio)

--- a/extent_io.c
+++ b/extent_io.c
@@ -3321,10 +3321,11 @@ static int btrfs_bio_add_page(struct btrfs_bio_ctrl *bio_ctrl,
 	if (real_size == 0)
 		return 0;
 
-	if (bio_op(bio) == REQ_OP_ZONE_APPEND)
-		ret = bio_add_zone_append_page(bio, page, real_size, pg_offset);
-	else
-		ret = bio_add_page(bio, page, real_size, pg_offset);
+	/*
+	 * RHEL 10.1 kernel 6.12: bio_add_zone_append_page() was removed.
+	 * bio_add_page() now handles all cases including REQ_OP_ZONE_APPEND.
+	 */
+	ret = bio_add_page(bio, page, real_size, pg_offset);
 
 	return ret;
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Creates btrfs build compatible for RHEL10.1.

-----

**Testing done**
```
[root@ip-10-13-245-111 px-btrfs]# ls -al fs/btrfs/btrfs.ko lib/zstd/zstd_compress.ko
ls: cannot access 'fs/btrfs/btrfs.ko': No such file or directory
ls: cannot access 'lib/zstd/zstd_compress.ko': No such file or directory
[root@ip-10-13-245-111 px-btrfs]# cd ~/rpmbuild/BUILD/kernel-6.12.0-124.20.1.el10_1/linux-6.12.0-124.20.1.el10.x86_64/
[root@ip-10-13-245-111 linux-6.12.0-124.20.1.el10.x86_64]# ls -al fs/btrfs/btrfs.ko lib/zstd/zstd_compress.ko
-rw-r--r--. 1 root root 40465080 Jan 13 05:49 fs/btrfs/btrfs.ko
-rw-r--r--. 1 root root  6740848 Jan 13 04:25 lib/zstd/zstd_compress.ko
[root@ip-10-13-245-111 linux-6.12.0-124.20.1.el10.x86_64]# modinfo fs/btrfs/btrfs.ko
filename:       /root/rpmbuild/BUILD/kernel-6.12.0-124.20.1.el10_1/linux-6.12.0-124.20.1.el10.x86_64/fs/btrfs/btrfs.ko
softdep:        pre: blake2b-256
softdep:        pre: sha256
softdep:        pre: xxhash64
softdep:        pre: crc32c
license:        GPL
alias:          devname:btrfs-control
alias:          char-major-10-234
alias:          fs-btrfs
rhelversion:    10.1
srcversion:     26E0BF9A205DA8C818051AC
depends:        zstd_compress,raid6_pq,xor
name:           btrfs
retpoline:      Y
vermagic:       6.12.0 SMP preempt mod_unload modversions

[root@ip-10-13-245-111 px-btrfs]# lsmod | egrep btrfs
btrfs                2179072  0
zstd_compress         528384  1 btrfs
raid6_pq              122880  1 btrfs
xor                    20480  1 btrfs


[root@ip-10-13-245-111 btrfs-progs]# make test
  CC       btrfs.o
  CC       kernel-lib/list_sort.o
  CC       kernel-lib/raid56.o
  CC       kernel-lib/rbtree.o
  CC       kernel-lib/tables.o
  CC       kernel-shared/accessors.o
  CC       kernel-shared/async-thread.o
  CC       kernel-shared/backref.o
  CC       kernel-shared/ctree.o
  CC       kernel-shared/delayed-ref.o
  CC       kernel-shared/dir-item.o
  CC       kernel-shared/disk-io.o
  CC       kernel-shared/extent-io-tree.o
  CC       kernel-shared/extent-tree.o
  CC       kernel-shared/extent_io.o
  CC       kernel-shared/file-item.o
  CC       kernel-shared/file.o
  CC       kernel-shared/free-space-cache.o
  CC       kernel-shared/free-space-tree.o
  CC       kernel-shared/inode-item.o
  CC       kernel-shared/inode.o
  CC       kernel-shared/locking.o
  CC       kernel-shared/messages.o
  CC       kernel-shared/print-tree.o
  CC       kernel-shared/root-tree.o
  CC       kernel-shared/transaction.o
  CC       kernel-shared/tree-checker.o
  CC       kernel-shared/ulist.o
  CC       kernel-shared/uuid-tree.o
  CC       kernel-shared/volumes.o
  CC       kernel-shared/zoned.o
  CC       common/array.o
  CC       common/compat.o
  CC       common/cpu-utils.o
  CC       common/device-scan.o
  CC       common/device-utils.o
  CC       common/extent-cache.o
  CC       common/extent-tree-utils.o
  CC       common/root-tree-utils.o
  CC       common/filesystem-utils.o
  CC       common/format-output.o
  CC       common/fsfeatures.o
  CC       common/help.o
  CC       common/inject-error.o
  CC       common/messages.o
  CC       common/open-utils.o
  CC       common/parse-utils.o
  CC       common/path-utils.o
  CC       common/rbtree-utils.o
  CC       common/send-stream.o
  CC       common/send-utils.o
  CC       common/sort-utils.o
  CC       common/string-table.o
  CC       common/string-utils.o
  CC       common/sysfs-utils.o
  CC       common/task-utils.o
  CC       common/units.o
  CC       common/utils.o
  CC       check/qgroup-verify.o
  CC       check/repair.o
  CC       cmds/receive-dump.o
  CC       crypto/crc32c.o
  CC       crypto/hash.o
  CC       crypto/xxhash.o
  CC       crypto/sha224-256.o
  CC       crypto/blake2b-ref.o
  CC       crypto/blake2b-sse2.o
  CC       crypto/blake2b-sse41.o
  CC       crypto/blake2b-avx2.o
  CC       crypto/sha256-x86.o
  AS       crypto/crc32c-pcl-intel-asm_64.o
  CC       libbtrfsutil/stubs.o
  CC       libbtrfsutil/subvolume.o
  CC       cmds/subvolume.o
  CC       cmds/subvolume-list.o
  CC       cmds/filesystem.o
  CC       cmds/device.o
  CC       cmds/scrub.o
  CC       cmds/inspect.o
  CC       cmds/balance.o
  CC       cmds/send.o
  CC       cmds/receive.o
  CC       cmds/quota.o
  CC       cmds/qgroup.o
  CC       cmds/replace.o
  CC       check/main.o
  CC       cmds/restore.o
  CC       cmds/rescue.o
  CC       cmds/rescue-chunk-recover.o
  CC       cmds/rescue-super-recover.o
  CC       cmds/rescue-fix-data-checksum.o
  CC       cmds/property.o
  CC       cmds/filesystem-usage.o
  CC       cmds/inspect-dump-tree.o
  CC       cmds/inspect-dump-super.o
  CC       cmds/inspect-tree-stats.o
  CC       cmds/filesystem-du.o
  CC       cmds/reflink.o
  CC       mkfs/common.o
  CC       check/mode-common.o
  CC       check/mode-lowmem.o
  CC       common/clear-cache.o
  CC       libbtrfsutil/errors.o
  CC       libbtrfsutil/filesystem.o
  CC       libbtrfsutil/qgroup.o
  AR       libbtrfsutil.a
  LD       btrfs
  CC       image/main.o
  CC       image/sanitize.o
  CC       image/image-create.o
  CC       image/common.o
  CC       image/image-restore.o
  LD       btrfs-image
  CC       btrfs-corrupt-block.o
  LD       btrfs-corrupt-block
  CC       mkfs/main.o
  CC       mkfs/rootdir.o
  LD       mkfs.btrfs
  CC       tune/main.o
  CC       tune/seeding.o
  CC       tune/change-uuid.o
  CC       tune/change-metadata-uuid.o
  CC       tune/convert-bgt.o
  CC       tune/change-csum.o
  CC       tune/quota.o
  LD       btrfstune
  TEST     fsck-tests.sh
    [TEST/fsck]   001-bad-file-extent-bytenr
    [TEST/fsck]   002-bad-transid
    [TEST/fsck]   003-shift-offsets
    [TEST/fsck]   004-no-dir-index
    [TEST/fsck]   005-bad-item-offset
    [TEST/fsck]   006-bad-root-items
    [TEST/fsck]   007-bad-offset-snapshots
    [TEST/fsck]   008-bad-dir-index-name
    [TEST/fsck]   009-no-dir-item-or-index
    [TEST/fsck]   010-no-rootdir-inode-item
    [TEST/fsck]   011-no-inode-item
    [TEST/fsck]   012-leaf-corruption
    [TEST/fsck]   013-extent-tree-rebuild
    [TEST/fsck]   014-no-extent-info
    [TEST/fsck]   016-wrong-inode-nbytes
    [TEST/fsck]   017-missing-all-file-extent
    [TEST/fsck]   018-leaf-crossing-stripes
    [TEST/fsck]   019-non-skinny-false-alert
    [TEST/fsck]   020-extent-ref-cases
    [TEST/fsck]   021-partially-dropped-snapshot-case
    [TEST/fsck]   022-qgroup-rescan-halfway
    [TEST/fsck]   023-qgroup-stack-overflow
    [TEST/fsck]   024-clear-space-cache
    [TEST/fsck]   025-file-extents
    [TEST/fsck]   026-bad-dir-item-name
    [TEST/fsck]   027-bad-extent-inline-ref-type
    [TEST/fsck]   028-unaligned-super-dev-sizes
    [TEST/fsck]   029-valid-orphan-item
    [TEST/fsck]   030-reflinked-prealloc-extents
    [TEST/fsck]   031-metadatadump-check-data-csum
    [TEST/fsck]   032-corrupted-qgroup
    [TEST/fsck]   033-lowmem-collission-dir-items
    [TEST/fsck]   034-bad-inode-flags
    [TEST/fsck]   035-inline-bad-ram-bytes
    [TEST/fsck]   036-bad-dev-extents
    [TEST/fsck]   036-rescan-not-kicked-in
    [TEST/fsck]   037-freespacetree-repair
    [TEST/fsck]   038-missing-one-file-extent
    [TEST/fsck]   039-bad-inode-mode
    [TEST/fsck]   040-compressed-nodatasum
    [TEST/fsck]   041-invalid-root-generation
    [TEST/fsck]   042-half-dropped-inode
    [TEST/fsck]   043-bad-inode-generation
    [TEST/fsck]   044-invalid-extent-item-generation
    [TEST/fsck]   045-overlap-csum-item
    [TEST/fsck]   047-dev-bytes-used
    [TEST/fsck]   049-dir-hard-link
    [TEST/fsck]   050-invalid-block-group-used
    [TEST/fsck]   051-invalid-super-bytes-used
    [TEST/fsck]   052-init-csum-tree
    [TEST/fsck]   053-bad-metadata-level
    [TEST/fsck]   054-orphan-directory
    [TEST/fsck]   055-super-num-devs-mismatch
    [TEST/fsck]   056-raid56-false-alerts
    [TEST/fsck]   057-seed-false-alerts
    [TEST/fsck]   058-bad-free-space-tree-entry
    [TEST/fsck]   059-shrunk-device
    [TEST/fsck]   060-degraded-check
    [TEST/fsck]   061-out-of-order-inline-backref
    [TEST/fsck]   063-log-missing-csum
    [TEST/fsck]   064-deprecated-inode-cache
    [TEST/fsck]   065-valid-log-tree
    [TEST/fsck]   066-missing-root-orphan-item
    [TEST/fsck]   067-dupe-filename
    [TEST/fsck]   068-orphan-dev-extent
  TEST     mkfs-tests.sh
    [TEST/mkfs]   001-basic-profiles
    [TEST/mkfs]   002-no-force-mixed-on-small-volume
    [TEST/mkfs]   003-mixed-with-wrong-nodesize
    [TEST/mkfs]   004-rootdir-keeps-size
    [TEST/mkfs]   005-long-device-name-for-ssd
    [TEST/mkfs]   006-partitioned-loopdev
    [TEST/mkfs]   007-mix-nodesize-sectorsize
    [TEST/mkfs]   008-sectorsize-nodesize-combination
    [TEST/mkfs]   009-special-files-for-rootdir
    [TEST/mkfs]   010-minimal-size
    [TEST/mkfs]   011-rootdir-create-file
    [TEST/mkfs]   012-rootdir-no-shrink
    [TEST/mkfs]   013-reserved-1M-for-single
    [TEST/mkfs]   014-rootdir-inline-extent
    [TEST/mkfs]   015-fstree-uuid-otime
    [TEST/mkfs]   016-rootdir-bad-symbolic-link
    [TEST/mkfs]   017-small-backing-size-thin-provision-device
    [TEST/mkfs]   018-multidevice-overflow
    [TEST/mkfs]   019-basic-checksums-mkfs
    [TEST/mkfs]   020-basic-checksums-mount
    [TEST/mkfs]   021-rfeatures-quota-rootdir
    [TEST/mkfs]   022-rootdir-size
    [TEST/mkfs]   023-free-space-tree
    [TEST/mkfs]   024-fst-bitmaps
    [TEST/mkfs]   025-zoned-parallel
    [TEST/mkfs]   026-extent-tree-to-bgt
    [TEST/mkfs]   027-rootdir-inode
    [TEST/mkfs]   028-block-group-tree
    [TEST/mkfs]   029-raid-stripe-tree
    [NOTRUN] This test requires experimental build
    [TEST/mkfs]   030-zoned-rst
    [NOTRUN] This test requires experimental build
```

------

**Which issue(s) this PR fixes** (optional)
Closes #
[PWX-49482](https://purestorage.atlassian.net/browse/PWX-49482)

**Special notes for your reviewer**:



[PWX-49482]: https://purestorage.atlassian.net/browse/PWX-49482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ