### PR TITLE
CentOS kernel compatibility changes

### DIFF
--- a/acl.c
+++ b/acl.c
@@ -16,15 +16,14 @@
 #include "btrfs_inode.h"
 #include "xattr.h"
 
-struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu)
+struct posix_acl *btrfs_get_acl(struct mnt_idmap *idmap, struct dentry *dentry,
+				int type)
 {
 	int size;
 	const char *name;
 	char *value = NULL;
 	struct posix_acl *acl;
-
-	if (rcu)
-		return ERR_PTR(-ECHILD);
+	struct inode *inode = d_inode(dentry);
 
 	switch (type) {
 	case ACL_TYPE_ACCESS:
@@ -56,7 +55,7 @@ struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu)
 }
 
 static int __btrfs_set_acl(struct btrfs_trans_handle *trans,
-			   struct user_namespace *mnt_userns,
+			   struct mnt_idmap *idmap,
 			   struct inode *inode, struct posix_acl *acl, int type)
 {
 	int ret, size = 0;
@@ -111,19 +110,20 @@ out:
 	return ret;
 }
 
-int btrfs_set_acl(struct user_namespace *mnt_userns, struct inode *inode,
+int btrfs_set_acl(struct mnt_idmap *idmap, struct dentry *dentry,
 		  struct posix_acl *acl, int type)
 {
 	int ret;
+	struct inode *inode = d_inode(dentry);
 	umode_t old_mode = inode->i_mode;
 
 	if (type == ACL_TYPE_ACCESS && acl) {
-		ret = posix_acl_update_mode(mnt_userns, inode,
+		ret = posix_acl_update_mode(idmap, inode,
 					    &inode->i_mode, &acl);
 		if (ret)
 			return ret;
 	}
-	ret = __btrfs_set_acl(NULL, mnt_userns, inode, acl, type);
+	ret = __btrfs_set_acl(NULL, idmap, inode, acl, type);
 	if (ret)
 		inode->i_mode = old_mode;
 	return ret;
@@ -144,14 +144,14 @@ int btrfs_init_acl(struct btrfs_trans_handle *trans,
 		return ret;
 
 	if (default_acl) {
-		ret = __btrfs_set_acl(trans, &init_user_ns, inode, default_acl,
+		ret = __btrfs_set_acl(trans, &nop_mnt_idmap, inode, default_acl,
 				      ACL_TYPE_DEFAULT);
 		posix_acl_release(default_acl);
 	}
 
 	if (acl) {
 		if (!ret)
-			ret = __btrfs_set_acl(trans, &init_user_ns, inode, acl,
+			ret = __btrfs_set_acl(trans, &nop_mnt_idmap, inode, acl,
 					      ACL_TYPE_ACCESS);
 		posix_acl_release(acl);
 	}

--- a/compression.c
+++ b/compression.c
@@ -578,12 +578,9 @@ blk_status_t btrfs_submit_compressed_write(struct btrfs_inode *inode, u64 start,
 		real_size = min_t(u64, real_size, compressed_len - offset);
 		ASSERT(IS_ALIGNED(real_size, fs_info->sectorsize));
 
-		if (use_append)
-			added = bio_add_zone_append_page(bio, page, real_size,
-					offset_in_page(offset));
-		else
-			added = bio_add_page(bio, page, real_size,
-					offset_in_page(offset));
+		/* Kernel 6.12: bio_add_zone_append_page was removed, use bio_add_page for all ops */
+		added = bio_add_page(bio, page, real_size,
+				offset_in_page(offset));
 		/* Reached zoned boundary */
 		if (added == 0)
 			submit = true;

--- a/ctree.h
+++ b/ctree.h
@@ -3754,8 +3754,9 @@ static inline int __btrfs_fs_compat_ro(struct btrfs_fs_info *fs_info, u64 flag)
 
 /* acl.c */
 #ifdef CONFIG_BTRFS_FS_POSIX_ACL
-struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu);
-int btrfs_set_acl(struct user_namespace *mnt_userns, struct inode *inode,
+struct posix_acl *btrfs_get_acl(struct mnt_idmap *idmap, struct dentry *dentry,
+				int type);
+int btrfs_set_acl(struct mnt_idmap *idmap, struct dentry *dentry,
 		  struct posix_acl *acl, int type);
 int btrfs_init_acl(struct btrfs_trans_handle *trans,
 		   struct inode *inode, struct inode *dir);
@@ -3883,10 +3884,11 @@ static inline bool btrfs_is_data_reloc_root(const struct btrfs_root *root)
  * unfinished IO.
  *
  * Rename the Private2 accessors to Ordered, to improve readability.
+ * In kernel 6.12+, PagePrivate2 was removed, so we use folio-based APIs.
  */
-#define PageOrdered(page)		PagePrivate2(page)
-#define SetPageOrdered(page)		SetPagePrivate2(page)
-#define ClearPageOrdered(page)		ClearPagePrivate2(page)
+#define PageOrdered(page)		folio_test_private_2(page_folio(page))
+#define SetPageOrdered(page)		folio_set_private_2(page_folio(page))
+#define ClearPageOrdered(page)		folio_clear_private_2(page_folio(page))
 #define folio_test_ordered(folio)	folio_test_private_2(folio)
 #define folio_set_ordered(folio)	folio_set_private_2(folio)
 #define folio_clear_ordered(folio)	folio_clear_private_2(folio)

--- a/extent_io.c
+++ b/extent_io.c
@@ -3321,10 +3321,8 @@ static int btrfs_bio_add_page(struct btrfs_bio_ctrl *bio_ctrl,
 	if (real_size == 0)
 		return 0;
 
-	if (bio_op(bio) == REQ_OP_ZONE_APPEND)
-		ret = bio_add_zone_append_page(bio, page, real_size, pg_offset);
-	else
-		ret = bio_add_page(bio, page, real_size, pg_offset);
+	/* Kernel 6.12: bio_add_zone_append_page was removed, use bio_add_page for all ops */
+	ret = bio_add_page(bio, page, real_size, pg_offset);
 
 	return ret;
 }

--- a/xattr.c
+++ b/xattr.c
@@ -455,10 +455,6 @@ static const struct xattr_handler btrfs_btrfs_xattr_handler = {
 
 const struct xattr_handler *btrfs_xattr_handlers[] = {
 	&btrfs_security_xattr_handler,
-#ifdef CONFIG_BTRFS_FS_POSIX_ACL
-	&posix_acl_access_xattr_handler,
-	&posix_acl_default_xattr_handler,
-#endif
 	&btrfs_trusted_xattr_handler,
 	&btrfs_user_xattr_handler,
 	&btrfs_btrfs_xattr_handler,


### PR DESCRIPTION
**What this PR does / why we need it**:
Build px-btrfs module for CentOS 10. 

## Build:
```
:~/my-btrfs-build# make -C /lib/modules/$(uname -r)/build M=$(pwd)/fs/btrfs/ modules
make: Entering directory '/usr/src/kernels/6.12.0-205.el10.x86_64'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: gcc (GCC) 14.3.1 20251022 (Red Hat 14.3.1-4)
  You are using:           gcc (GCC) 14.3.1 20250617 (Red Hat 14.3.1-2)
  CC [M]  /root/my-btrfs-build/fs/btrfs/compression.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/delayed-ref.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/relocation.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/delayed-inode.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/scrub.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/backref.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/ulist.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/qgroup.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/send.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/dev-replace.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/raid56.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/uuid-tree.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/props.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/free-space-tree.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/tree-checker.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/space-info.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/block-rsv.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/delalloc-space.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/block-group.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/discard.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/reflink.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/subpage.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/tree-mod-log.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/acl.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/zoned.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/verity.o
  LD [M]  /root/my-btrfs-build/fs/btrfs/btrfs.o
  MODPOST /root/my-btrfs-build/fs/btrfs/Module.symvers
  CC [M]  /root/my-btrfs-build/fs/btrfs/btrfs.mod.o
  CC [M]  /root/my-btrfs-build/fs/btrfs/.module-common.o
  LD [M]  /root/my-btrfs-build/fs/btrfs/btrfs.ko
  BTF [M] /root/my-btrfs-build/fs/btrfs/btrfs.ko
Skipping BTF generation for /root/my-btrfs-build/fs/btrfs/btrfs.ko due to unavailability of vmlinux
make: Leaving directory '/usr/src/kernels/6.12.0-205.el10.x86_64'


:~/my-btrfs-build# ls -lh fs/btrfs/btrfs.ko
-rw-r--r-- 1 root root 40M Feb 27 01:49 fs/btrfs/btrfs.ko


:~/my-btrfs-build# modinfo fs/btrfs/btrfs.ko | head -20
filename:       /root/my-btrfs-build/fs/btrfs/btrfs.ko
softdep:        pre: blake2b-256
softdep:        pre: sha256
softdep:        pre: xxhash64
softdep:        pre: crc32c
license:        GPL
alias:          devname:btrfs-control
alias:          char-major-10-234
alias:          fs-btrfs
rhelversion:    10.2
srcversion:     23D20FD3A2385E06303C2AD
depends:        zstd_compress,raid6_pq,xor
name:           btrfs
retpoline:      Y
vermagic:       6.12.0-205.el10.x86_64 SMP preempt mod_unload modversions 

:~/my-btrfs-build# KERNEL_VER=$(uname -r)

:~/my-btrfs-build# for i in /root/my-btrfs-build/crypto/xor.ko /root/my-btrfs-build/lib/raid6/raid6_pq.ko; do modprobe $i; done
for i in  /root/my-btrfs-build/lib/zstd/zstd_compress.ko  /root/my-btrfs-build/fs/btrfs/btrfs.ko; do insmod $i; done
root@ip-10-13-198-67:~/my-btrfs-build# if lsmod | grep -q '^btrfs'; then
    echo "OK: btrfs module is loaded."
else
    echo "ERROR: btrfs module not found or failed to load."
    exit 1
fi
OK: btrfs module is loaded.

:~/my-btrfs-build# lsmod | grep btrfs
btrfs                2183168  0
zstd_compress         528384  1 btrfs
raid6_pq              122880  1 btrfs
xor                    24576  1 btrfs
```

## Test

```
# Commands:
sudo dnf install libuuid-devel -y
sudo dnf install libblkid-devel -y
sudo dnf install systemd-devel -y
sudo dnf install lzo-devel -y
sudo dnf install libzstd-devel -y
sudo dnf install libaio-devel -y
sudo dnf install e2fsprogs-devel lzo-devel python3-devel automake autoconf -y
sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms 
sudo dnf install liburing-devel -y
git clone https://github.com/kdave/btrfs-progs.git
cd btrfs-progs
./autogen.sh
./configure --disable-documentation
# disable tests related to zoned in tests/mkfs-tests/ and tests/misc-tests/
make test


# Output:

config.status: creating include/config.h

        btrfs-progs:        v6.19
        libbtrfs:           0.1.5 (deprecated)
        libbtrfsutil:       1.4.0

        prefix:             /usr/local
        exec prefix:        ${prefix}

        bindir:             ${exec_prefix}/bin
        libdir:             ${exec_prefix}/lib
        includedir:         ${prefix}/include
        pkgconfigdir:       ${libdir}/pkgconfig

        compiler:           gcc
        CFLAGS:             -g -O2 -Wall -D_FORTIFY_SOURCE=2
        LDFLAGS:            

        programs:           yes
        shared libraries:   yes
        static libraries:   yes
        documentation:      no
        doc generator:      none
        backtrace support:  yes
        btrfs-convert:      yes (ext2)
        zstd support:       yes
        lzo support:        yes
        fsverity support:   yes
        Python bindings:    yes
        Python interpreter: /usr/bin/python
        crypto provider:    builtin 
        libudev:            yes
        zoned device:       yes

        Type 'make' to compile.

  CC       btrfs.o
  CC       kernel-lib/list_sort.o
  CC       kernel-lib/raid56.o
  CC       kernel-lib/rbtree.o
  CC       kernel-lib/tables.o
  CC       kernel-shared/accessors.o
  CC       kernel-shared/async-thread.o
  CC       kernel-shared/backref.o
  CC       kernel-shared/ctree.o
  CC       kernel-shared/delayed-ref.o
  CC       kernel-shared/dir-item.o
  CC       kernel-shared/disk-io.o
  CC       kernel-shared/extent-io-tree.o
  CC       kernel-shared/extent-tree.o
  CC       kernel-shared/extent_io.o
  CC       kernel-shared/file-item.o
  CC       kernel-shared/file.o
  CC       kernel-shared/free-space-cache.o
  CC       kernel-shared/free-space-tree.o
  CC       kernel-shared/inode-item.o
  CC       kernel-shared/inode.o
  CC       kernel-shared/locking.o
  CC       kernel-shared/messages.o
  CC       kernel-shared/print-tree.o
  CC       kernel-shared/root-tree.o
  CC       kernel-shared/transaction.o
  CC       kernel-shared/tree-checker.o
  CC       kernel-shared/ulist.o
  CC       kernel-shared/uuid-tree.o
  CC       kernel-shared/volumes.o
  CC       kernel-shared/zoned.o
  CC       common/array.o
  CC       common/compat.o
  CC       common/cpu-utils.o
  CC       common/device-scan.o
  CC       common/device-utils.o
  CC       common/extent-cache.o
  CC       common/extent-tree-utils.o
  CC       common/root-tree-utils.o
  CC       common/filesystem-utils.o
  CC       common/format-output.o
  CC       common/fsfeatures.o
  CC       common/help.o
  CC       common/inject-error.o
  CC       common/messages.o
  CC       common/open-utils.o
  CC       common/parse-utils.o
  CC       common/path-utils.o
  CC       common/rbtree-utils.o
  CC       common/send-stream.o
  CC       common/send-utils.o
  CC       common/sort-utils.o
  CC       common/string-table.o
  CC       common/string-utils.o
  CC       common/sysfs-utils.o
  CC       common/task-utils.o
  CC       common/units.o
  CC       common/utils.o
  CC       check/qgroup-verify.o
  CC       check/repair.o
  CC       cmds/receive-dump.o
  CC       crypto/crc32c.o
  CC       crypto/hash.o
  CC       crypto/xxhash.o
  CC       crypto/sha224-256.o
  CC       crypto/blake2b-ref.o
  CC       crypto/blake2b-sse2.o
  CC       crypto/blake2b-sse41.o
  CC       crypto/blake2b-avx2.o
  CC       crypto/sha256-x86.o
  AS       crypto/crc32c-pcl-intel-asm_64.o
  CC       libbtrfsutil/stubs.o
  CC       libbtrfsutil/subvolume.o
  CC       cmds/subvolume.o
  CC       cmds/subvolume-list.o
  CC       cmds/filesystem.o
  CC       cmds/device.o
  CC       cmds/scrub.o
  CC       cmds/inspect.o
  CC       cmds/balance.o
  CC       cmds/send.o
  CC       cmds/receive.o
  CC       cmds/quota.o
  CC       cmds/qgroup.o
  CC       cmds/replace.o
  CC       check/main.o
  CC       cmds/restore.o
  CC       cmds/rescue.o
  CC       cmds/rescue-chunk-recover.o
  CC       cmds/rescue-super-recover.o
  CC       cmds/rescue-fix-data-checksum.o
  CC       cmds/property.o
  CC       cmds/filesystem-usage.o
  CC       cmds/inspect-dump-tree.o
  CC       cmds/inspect-dump-super.o
  CC       cmds/inspect-tree-stats.o
  CC       cmds/filesystem-du.o
  CC       cmds/reflink.o
  CC       mkfs/common.o
  CC       check/mode-common.o
CC       check/mode-lowmem.o
  CC       common/clear-cache.o
  CC       libbtrfsutil/errors.o
  CC       libbtrfsutil/filesystem.o
  CC       libbtrfsutil/qgroup.o
  AR       libbtrfsutil.a
  LD       btrfs
  CC       image/main.o
  CC       image/sanitize.o
  CC       image/image-create.o
  CC       image/common.o
  CC       image/image-restore.o
  LD       btrfs-image
  CC       btrfs-corrupt-block.o
  LD       btrfs-corrupt-block
  CC       mkfs/main.o
  CC       mkfs/rootdir.o
  LD       mkfs.btrfs
  CC       tune/main.o
  CC       tune/seeding.o
  CC       tune/change-uuid.o
  CC       tune/change-metadata-uuid.o
  CC       tune/convert-bgt.o
  CC       tune/change-csum.o
  CC       tune/quota.o
  LD       btrfstune
# cd /root/btrfs-progs && make test 2>&1
  TEST     fsck-tests.sh
    [TEST/fsck]   001-bad-file-extent-bytenr
    [TEST/fsck]   002-bad-transid
    [TEST/fsck]   003-shift-offsets
    [TEST/fsck]   004-no-dir-index
    [TEST/fsck]   005-bad-item-offset
    [TEST/fsck]   006-bad-root-items
    [TEST/fsck]   007-bad-offset-snapshots
    [TEST/fsck]   008-bad-dir-index-name
    [TEST/fsck]   009-no-dir-item-or-index
    [TEST/fsck]   010-no-rootdir-inode-item
    [TEST/fsck]   011-no-inode-item
    [TEST/fsck]   012-leaf-corruption
    [TEST/fsck]   013-extent-tree-rebuild
    [TEST/fsck]   014-no-extent-info
    [TEST/fsck]   016-wrong-inode-nbytes
    [TEST/fsck]   017-missing-all-file-extent
    [TEST/fsck]   018-leaf-crossing-stripes
    [TEST/fsck]   019-non-skinny-false-alert
    [TEST/fsck]   020-extent-ref-cases
    [TEST/fsck]   021-partially-dropped-snapshot-case
    [TEST/fsck]   022-qgroup-rescan-halfway
    [TEST/fsck]   023-qgroup-stack-overflow
    [TEST/fsck]   024-clear-space-cache
    [TEST/fsck]   025-file-extents
    [TEST/fsck]   026-bad-dir-item-name
    [TEST/fsck]   027-bad-extent-inline-ref-type
    [TEST/fsck]   028-unaligned-super-dev-sizes
    [TEST/fsck]   029-valid-orphan-item
    [TEST/fsck]   030-reflinked-prealloc-extents
    [TEST/fsck]   031-metadatadump-check-data-csum
    [TEST/fsck]   032-corrupted-qgroup
    [TEST/fsck]   033-lowmem-collission-dir-items
    [TEST/fsck]   034-bad-inode-flags
    [TEST/fsck]   035-inline-bad-ram-bytes
    [TEST/fsck]   036-bad-dev-extents
    [TEST/fsck]   036-rescan-not-kicked-in
    [TEST/fsck]   037-freespacetree-repair
    [TEST/fsck]   038-missing-one-file-extent
    [TEST/fsck]   039-bad-inode-mode
    [TEST/fsck]   040-compressed-nodatasum
    [TEST/fsck]   041-invalid-root-generation
    [TEST/fsck]   042-half-dropped-inode
    [TEST/fsck]   043-bad-inode-generation
    [TEST/fsck]   044-invalid-extent-item-generation
    [TEST/fsck]   045-overlap-csum-item
    [TEST/fsck]   047-dev-bytes-used
    [TEST/fsck]   049-dir-hard-link
    [TEST/fsck]   050-invalid-block-group-used
    [TEST/fsck]   051-invalid-super-bytes-used
    [TEST/fsck]   052-init-csum-tree
    [TEST/fsck]   053-bad-metadata-level
    [TEST/fsck]   054-orphan-directory
    [TEST/fsck]   055-super-num-devs-mismatch
    [TEST/fsck]   056-raid56-false-alerts
    [TEST/fsck]   057-seed-false-alerts
    [TEST/fsck]   058-bad-free-space-tree-entry
    [TEST/fsck]   059-shrunk-device
    [TEST/fsck]   060-degraded-check
    [TEST/fsck]   061-out-of-order-inline-backref
    [TEST/fsck]   063-log-missing-csum
    [TEST/fsck]   064-deprecated-inode-cache
    [TEST/fsck]   065-valid-log-tree
    [TEST/fsck]   066-missing-root-orphan-item
    [TEST/fsck]   067-dupe-filename
    [TEST/fsck]   068-orphan-dev-extent
    [TEST/fsck]   069-unknown-fs-tree-key
    [TEST/fsck]   070-missing-inode-ref
    [TEST/fsck]   071-orphan-fst-entry
  TEST     mkfs-tests.sh
    [TEST/mkfs]   001-basic-profiles
    [TEST/mkfs]   002-no-force-mixed-on-small-volume
    [TEST/mkfs]   003-mixed-with-wrong-nodesize
    [TEST/mkfs]   004-rootdir-keeps-size
    [TEST/mkfs]   005-long-device-name-for-ssd
    [TEST/mkfs]   006-partitioned-loopdev
    [TEST/mkfs]   007-mix-nodesize-sectorsize
    [TEST/mkfs]   008-sectorsize-nodesize-combination
    [TEST/mkfs]   009-special-files-for-rootdir
    [TEST/mkfs]   010-minimal-size
    [TEST/mkfs]   011-rootdir-create-file
    [TEST/mkfs]   012-rootdir-no-shrink
    [TEST/mkfs]   013-reserved-1M-for-single
    [TEST/mkfs]   014-rootdir-inline-extent
    [TEST/mkfs]   015-fstree-uuid-otime
    [TEST/mkfs]   016-rootdir-bad-symbolic-link
    [TEST/mkfs]   017-small-backing-size-thin-provision-device
    [TEST/mkfs]   018-multidevice-overflow
    [TEST/mkfs]   019-basic-checksums-mkfs
    [TEST/mkfs]   020-basic-checksums-mount
    [TEST/mkfs]   021-rfeatures-quota-rootdir
    [TEST/mkfs]   022-rootdir-size
    [TEST/mkfs]   023-free-space-tree
    [TEST/mkfs]   024-fst-bitmaps
    [TEST/mkfs]   026-extent-tree-to-bgt
    [TEST/mkfs]   027-rootdir-inode
    [TEST/mkfs]   028-block-group-tree
    [TEST/mkfs]   029-raid-stripe-tree
    [NOTRUN] This test requires experimental build
    [TEST/mkfs]   034-rootdir-extra-hard-links
    [TEST/mkfs]   035-rootdir-cross-mount
    [TEST/mkfs]   036-rootdir-subvol
    [TEST/mkfs]   037-basic-compression
    [TEST/mkfs]   038-inode-flags
    [TEST/mkfs]   040-remap-tree
    [NOTRUN] btrfs check support for remap-tree missing
  TEST     misc-tests.sh
    [TEST/misc]   001-btrfstune-features
    [TEST/misc]   002-uuid-rewrite
    [TEST/misc]   003-zero-log
    [TEST/misc]   004-shrink-fs
    [TEST/misc]   005-convert-progress-thread-crash
    [TEST/misc]   006-image-on-missing-device
    [TEST/misc]   007-subvolume-sync
    [TEST/misc]   008-leaf-crossing-stripes
    [TEST/misc]   009-subvolume-sync-must-wait
    [TEST/misc]   010-convert-delete-ext2-subvol
    [TEST/misc]   011-delete-missing-device
    [TEST/misc]   012-find-root-no-result
    [TEST/misc]   013-subvolume-sync-crash
    [TEST/misc]   014-filesystem-label
    [TEST/misc]   015-dump-super-garbage
    [TEST/misc]   016-send-clone-src
    [TEST/misc]   017-recv-stream-malformatted
    [TEST/misc]   018-recv-end-of-stream
    [TEST/misc]   019-receive-clones-on-mounted-subvol
    [TEST/misc]   020-fix-superblock-corruption
    [TEST/misc]   021-image-multi-devices
    [TEST/misc]   022-filesystem-du-on-empty-subvol
    [TEST/misc]   023-device-usage-with-missing-device
    [TEST/misc]   024-inspect-internal-rootid
    [TEST/misc]   025-zstd-compression
    [TEST/misc]   026-image-non-printable-chars
    [TEST/misc]   027-subvol-list-deleted-toplevel
    [TEST/misc]   028-superblock-recover
    [TEST/misc]   029-send-p-different-mountpoints
    [TEST/misc]   030-missing-device-image
    [TEST/misc]   031-qgroup-parent-child-relation
    [TEST/misc]   032-bad-item-ptr
    [TEST/misc]   033-filename-length-limit
    [TEST/misc]   034-metadata-uuid
    [TEST/misc]   035-receive-common-mount-point-prefix
    [NOTRUN] fix not available
    [TEST/misc]   036-receive-dump-invalid-stream
    [TEST/misc]   037-fi-show-on-new-file
    [TEST/misc]   038-backup-root-corruption
    [TEST/misc]   039-receive-clone-from-current-subvolume
    [TEST/misc]   040-subvolume-delete-default
    [TEST/misc]   041-subvolume-delete-during-send
    [TEST/misc]   042-inspect-internal-logical-resolve
    [TEST/misc]   043-subvolume-set-default-toplevel
    [TEST/misc]   045-receive-check-mount-type
    [TEST/misc]   046-seed-multi-mount
    [TEST/misc]   047-raid5-convert
    [TEST/misc]   048-image-restore-mount
    [TEST/misc]   049-btrfstune-transid-mismatch
    [TEST/misc]   050-receive-prop-ro-to-rw
    [TEST/misc]   051-warning-rw-subvol-received-uuid
    [TEST/misc]   052-seed-dirty-log
    [TEST/misc]   053-receive-write-encoded
    [NOTRUN] kernel does not support send stream >1
    [TEST/misc]   054-receive-dump-newlines
    [TEST/misc]   055-qgroup-clear-stale
    [TEST/misc]   056-subvolume-list-uuid
    [TEST/misc]   057-btrfstune-free-space-tree
    [TEST/misc]   058-replace-start-enqueue
    [TEST/misc]   059-qgroup-show-stale-qgroup-crash
    [TEST/misc]   060-ino-cache-clean
    [TEST/misc]   061-reverse-receive
    [TEST/misc]   062-fi-show-raw-dm-all-devices
    [TEST/misc]   064-csum-conversion-basic
    [NOTRUN] This test requires experimental build
    [TEST/misc]   065-csum-conversion-inject
    [NOTRUN] This test requires experimental build
    [TEST/misc]   066-image-filename
    [TEST/misc]   067-btrfstune-simple-quota
    [NOTRUN] This test requires experimental build
    [TEST/misc]   068-subvol-delete-recursive-show-child
    [TEST/misc]   069-btrfstune-resume-bgt
    [TEST/misc]   070-offline-resize
  TEST     cli-tests.sh
    [TEST/cli]   001-btrfs
    [TEST/cli]   002-balance-full-no-filters
    [TEST/cli]   003-fi-resize-args
    [TEST/cli]   004-send-parent-multi-subvol
    [TEST/cli]   005-qgroup-show
    [TEST/cli]   006-qgroup-show-sync
    [TEST/cli]   007-check-force
    [TEST/cli]   008-subvolume-get-set-default
    [TEST/cli]   009-btrfstune
    [TEST/cli]   010-subvol-show-qgroup
    [TEST/cli]   011-defrag-recursion
    [TEST/cli]   012-fi-du-recursion
    [TEST/cli]   013-subvolume-delete-by-id
    [TEST/cli]   014-multiple-profiles-warning
    [TEST/cli]   015-defrag-compress
    [TEST/cli]   016-btrfs-fi-usage
    [TEST/cli]   017-fi-show-missing
    [TEST/cli]   019-subvolume-create-parents
    [TEST/cli]   020-dry-run
    [TEST/cli]   021-subvolume-multiple-arguments
    [TEST/cli]   022-fi-du-suffixes
    [TEST/cli]   023-device-delete-force
    [TEST/cli]   024-scrub-limit
    [TEST/cli]   025-subvolume-create-failures
  CC       btrfs-sb-mod.o
  LD       btrfs-sb-mod
  TEST     fuzz-tests.sh
    [TEST/fuzz]   001-simple-check-unmounted
    [TEST/fuzz]   002-simple-image
    [TEST/fuzz]   003-multi-check-unmounted
    [TEST/fuzz]   004-simple-dump-tree
    [TEST/fuzz]   005-simple-dump-super
    [TEST/fuzz]   006-simple-tree-stats
    [TEST/fuzz]   007-simple-super-recover
    [TEST/fuzz]   008-simple-chunk-recover
    [TEST/fuzz]   009-simple-zero-log
    [TEST/fuzz]   010-simple-sb
[NOTRUN] custom test script not found or lacks execution permission
  PY       libbtrfsutil
test_fs_start_sync (test_filesystem.TestFilesystem.test_fs_start_sync) ... ok
test_fs_sync (test_filesystem.TestFilesystem.test_fs_sync) ... ok
test_fs_wait_sync (test_filesystem.TestFilesystem.test_fs_wait_sync) ... ok
test_start_sync (test_filesystem.TestFilesystem.test_start_sync) ... ok
test_sync (test_filesystem.TestFilesystem.test_sync) ... ok
test_wait_sync (test_filesystem.TestFilesystem.test_wait_sync) ... ok
test_snapshot_inherit (test_qgroup.TestQgroup.test_snapshot_inherit) ... ok
test_subvolume_inherit (test_qgroup.TestQgroup.test_subvolume_inherit) ... ok
test_add_group (test_qgroup.TestQgroupInherit.test_add_group) ... ok
test_new (test_qgroup.TestQgroupInherit.test_new) ... ok
test_create_snapshot (test_subvolume.TestSubvolume.test_create_snapshot) ... ok
test_create_subvolume (test_subvolume.TestSubvolume.test_create_subvolume) ... ok
test_default_subvolume (test_subvolume.TestSubvolume.test_default_subvolume) ... ok
test_delete_subvolume (test_subvolume.TestSubvolume.test_delete_subvolume) ... ok
test_deleted_subvolumes (test_subvolume.TestSubvolume.test_deleted_subvolumes) ... ok
test_is_subvolume (test_subvolume.TestSubvolume.test_is_subvolume) ... ok
test_read_only (test_subvolume.TestSubvolume.test_read_only) ... ok
test_subvolume_create (test_subvolume.TestSubvolume.test_subvolume_create) ... ok
test_subvolume_default (test_subvolume.TestSubvolume.test_subvolume_default) ... ok
test_subvolume_delete (test_subvolume.TestSubvolume.test_subvolume_delete) ... ok
test_subvolume_get_id (test_subvolume.TestSubvolume.test_subvolume_get_id) ... ok
test_subvolume_get_info (test_subvolume.TestSubvolume.test_subvolume_get_info) ... ok
test_subvolume_get_info_unprivileged (test_subvolume.TestSubvolume.test_subvolume_get_info_unprivileged) ... ok
test_subvolume_get_path (test_subvolume.TestSubvolume.test_subvolume_get_path) ... ok
test_subvolume_id (test_subvolume.TestSubvolume.test_subvolume_id) ... ok
test_subvolume_id_error (test_subvolume.TestSubvolume.test_subvolume_id_error) ... ok
test_subvolume_info (test_subvolume.TestSubvolume.test_subvolume_info) ... ok
test_subvolume_info_unprivileged (test_subvolume.TestSubvolume.test_subvolume_info_unprivileged) ... ok
test_subvolume_is_valid (test_subvolume.TestSubvolume.test_subvolume_is_valid) ... ok
test_subvolume_iterator (test_subvolume.TestSubvolume.test_subvolume_iterator) ... ok
test_subvolume_iterator_fd_unprivileged (test_subvolume.TestSubvolume.test_subvolume_iterator_fd_unprivileged) ... ok
test_subvolume_iterator_race (test_subvolume.TestSubvolume.test_subvolume_iterator_race) ... ok
```

**Which issue(s) this PR fixes** (optional)
Closes # 

PWX-51701

**Special notes for your reviewer**:

Have disabled Block Group Tree feature of btrfs as of now for build and test. We do not use it for portworx.

Will enable it and make changes for the feature as per requirement. (Expecting it to be more than just compatibility changes).
