### PR TITLE
changes for btrfs build for rhel 10.2

### DIFF
--- a/acl.c
+++ b/acl.c
@@ -16,15 +16,14 @@
 #include "btrfs_inode.h"
 #include "xattr.h"
 
-struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu)
+struct posix_acl *btrfs_get_acl(struct mnt_idmap *idmap, struct dentry *dentry,
+				int type)
 {
+	struct inode *inode = d_inode(dentry);
 	int size;
 	const char *name;
 	char *value = NULL;
 	struct posix_acl *acl;
-
-	if (rcu)
-		return ERR_PTR(-ECHILD);
 
 	switch (type) {
 	case ACL_TYPE_ACCESS:
@@ -56,7 +55,6 @@ struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu)
 }
 
 static int __btrfs_set_acl(struct btrfs_trans_handle *trans,
-			   struct user_namespace *mnt_userns,
 			   struct inode *inode, struct posix_acl *acl, int type)
 {
 	int ret, size = 0;
@@ -111,19 +109,19 @@ out:
 	return ret;
 }
 
-int btrfs_set_acl(struct user_namespace *mnt_userns, struct inode *inode,
+int btrfs_set_acl(struct mnt_idmap *idmap, struct dentry *dentry,
 		  struct posix_acl *acl, int type)
 {
 	int ret;
+	struct inode *inode = d_inode(dentry);
 	umode_t old_mode = inode->i_mode;
 
 	if (type == ACL_TYPE_ACCESS && acl) {
-		ret = posix_acl_update_mode(mnt_userns, inode,
-					    &inode->i_mode, &acl);
+		ret = posix_acl_update_mode(idmap, inode, &inode->i_mode, &acl);
 		if (ret)
 			return ret;
 	}
-	ret = __btrfs_set_acl(NULL, mnt_userns, inode, acl, type);
+	ret = __btrfs_set_acl(NULL, inode, acl, type);
 	if (ret)
 		inode->i_mode = old_mode;
 	return ret;
@@ -144,15 +142,13 @@ int btrfs_init_acl(struct btrfs_trans_handle *trans,
 		return ret;
 
 	if (default_acl) {
-		ret = __btrfs_set_acl(trans, &init_user_ns, inode, default_acl,
-				      ACL_TYPE_DEFAULT);
+		ret = __btrfs_set_acl(trans, inode, default_acl, ACL_TYPE_DEFAULT);
 		posix_acl_release(default_acl);
 	}
 
 	if (acl) {
 		if (!ret)
-			ret = __btrfs_set_acl(trans, &init_user_ns, inode, acl,
-					      ACL_TYPE_ACCESS);
+			ret = __btrfs_set_acl(trans, inode, acl, ACL_TYPE_ACCESS);
 		posix_acl_release(acl);
 	}
 

--- a/ctree.h
+++ b/ctree.h
@@ -3754,8 +3754,9 @@ static inline int __btrfs_fs_compat_ro(struct btrfs_fs_info *fs_info, u64 flag)
 
 /* acl.c */
 #ifdef CONFIG_BTRFS_FS_POSIX_ACL
-struct posix_acl *btrfs_get_acl(struct inode *inode, int type, bool rcu);
-int btrfs_set_acl(struct user_namespace *mnt_userns, struct inode *inode,
+struct posix_acl *btrfs_get_acl(struct mnt_idmap *idmap, struct dentry *dentry,
+				int type);
+int btrfs_set_acl(struct mnt_idmap *idmap, struct dentry *dentry,
 		  struct posix_acl *acl, int type);
 int btrfs_init_acl(struct btrfs_trans_handle *trans,
 		   struct inode *inode, struct inode *dir);

--- a/xattr.c
+++ b/xattr.c
@@ -9,7 +9,6 @@
 #include <linux/rwsem.h>
 #include <linux/xattr.h>
 #include <linux/security.h>
-#include <linux/posix_acl_xattr.h>
 #include <linux/iversion.h>
 #include <linux/sched/mm.h>
 #include "ctree.h"
@@ -455,10 +454,6 @@ static const struct xattr_handler btrfs_btrfs_xattr_handler = {
 
 const struct xattr_handler *btrfs_xattr_handlers[] = {
 	&btrfs_security_xattr_handler,
-#ifdef CONFIG_BTRFS_FS_POSIX_ACL
-	&posix_acl_access_xattr_handler,
-	&posix_acl_default_xattr_handler,
-#endif
 	&btrfs_trusted_xattr_handler,
 	&btrfs_user_xattr_handler,
 	&btrfs_btrfs_xattr_handler,


### PR DESCRIPTION
**What this PR does / why we need it**:
Btrfs build for rhel 10.2.


**Which issue(s) this PR fixes** (optional)
Closes #

**Test Output**

```
CC       kernel-shared/zoned.o
  CC       common/fsfeatures.o
  CC       common/utils.o
  CC       cmds/filesystem.o
  CC       cmds/device.o
  CC       cmds/replace.o
  CC       check/main.o
  CC       cmds/filesystem-du.o
  CC       mkfs/common.o
  LD       btrfs
  LD       btrfs-image
  LD       btrfs-corrupt-block
  CC       mkfs/main.o
  LD       mkfs.btrfs
  LD       btrfstune
  TEST     fsck-tests.sh
    [TEST/fsck]   001-bad-file-extent-bytenr
    [TEST/fsck]   002-bad-transid
    [TEST/fsck]   003-shift-offsets
    [TEST/fsck]   004-no-dir-index
    [TEST/fsck]   005-bad-item-offset
    [TEST/fsck]   006-bad-root-items
    [TEST/fsck]   007-bad-offset-snapshots
    [TEST/fsck]   008-bad-dir-index-name
    [TEST/fsck]   009-no-dir-item-or-index
    [TEST/fsck]   010-no-rootdir-inode-item
    [TEST/fsck]   011-no-inode-item
    [TEST/fsck]   012-leaf-corruption
    [TEST/fsck]   013-extent-tree-rebuild
    [TEST/fsck]   014-no-extent-info
    [TEST/fsck]   016-wrong-inode-nbytes
    [TEST/fsck]   017-missing-all-file-extent
    [TEST/fsck]   018-leaf-crossing-stripes
    [TEST/fsck]   019-non-skinny-false-alert
    [TEST/fsck]   020-extent-ref-cases
    [TEST/fsck]   021-partially-dropped-snapshot-case
    [TEST/fsck]   022-qgroup-rescan-halfway
    [TEST/fsck]   023-qgroup-stack-overflow
    [TEST/fsck]   024-clear-space-cache
    [TEST/fsck]   025-file-extents
    [TEST/fsck]   026-bad-dir-item-name
    [TEST/fsck]   027-bad-extent-inline-ref-type
    [TEST/fsck]   028-unaligned-super-dev-sizes
    [TEST/fsck]   029-valid-orphan-item
    [TEST/fsck]   030-reflinked-prealloc-extents
    [TEST/fsck]   031-metadatadump-check-data-csum
    [TEST/fsck]   032-corrupted-qgroup
    [TEST/fsck]   033-lowmem-collission-dir-items
    [TEST/fsck]   034-bad-inode-flags
    [TEST/fsck]   035-inline-bad-ram-bytes
    [TEST/fsck]   036-bad-dev-extents
    [TEST/fsck]   036-rescan-not-kicked-in
    [TEST/fsck]   037-freespacetree-repair
    [TEST/fsck]   038-missing-one-file-extent
    [TEST/fsck]   039-bad-inode-mode
    [TEST/fsck]   040-compressed-nodatasum
    [TEST/fsck]   041-invalid-root-generation
    [TEST/fsck]   042-half-dropped-inode
    [TEST/fsck]   043-bad-inode-generation
    [TEST/fsck]   044-invalid-extent-item-generation
    [TEST/fsck]   045-overlap-csum-item
    [TEST/fsck]   047-dev-bytes-used
    [TEST/fsck]   049-dir-hard-link
    [TEST/fsck]   050-invalid-block-group-used
    [TEST/fsck]   051-invalid-super-bytes-used
    [TEST/fsck]   052-init-csum-tree
    [TEST/fsck]   053-bad-metadata-level
    [TEST/fsck]   054-orphan-directory
    [TEST/fsck]   055-super-num-devs-mismatch
    [TEST/fsck]   056-raid56-false-alerts
    [TEST/fsck]   057-seed-false-alerts
    [TEST/fsck]   058-bad-free-space-tree-entry
    [TEST/fsck]   059-shrunk-device
    [TEST/fsck]   060-degraded-check
    [TEST/fsck]   061-out-of-order-inline-backref
    [TEST/fsck]   063-log-missing-csum
    [TEST/fsck]   064-deprecated-inode-cache
    [TEST/fsck]   065-valid-log-tree
    [TEST/fsck]   066-missing-root-orphan-item
    [TEST/fsck]   067-dupe-filename
    [TEST/fsck]   068-orphan-dev-extent
    [TEST/fsck]   069-unknown-fs-tree-key
    [TEST/fsck]   070-missing-inode-ref
    [TEST/fsck]   071-orphan-fst-entry
    [TEST/fsck]   072-verity-items
    [TEST/fsck]   073-squota
    [NOTRUN] no kernel simple quota support
  LD       fssum
  LD       fsstress
  TEST     mkfs-tests.sh
    [TEST/mkfs]   001-basic-profiles
    [TEST/mkfs]   002-no-force-mixed-on-small-volume
    [TEST/mkfs]   003-mixed-with-wrong-nodesize
    [TEST/mkfs]   004-rootdir-keeps-size
    [TEST/mkfs]   005-long-device-name-for-ssd
    [TEST/mkfs]   006-partitioned-loopdev
    [TEST/mkfs]   007-mix-nodesize-sectorsize
    [TEST/mkfs]   008-sectorsize-nodesize-combination
    [TEST/mkfs]   009-special-files-for-rootdir
    [TEST/mkfs]   010-minimal-size
    [TEST/mkfs]   011-rootdir-create-file
    [TEST/mkfs]   012-rootdir-no-shrink
    [TEST/mkfs]   013-reserved-1M-for-single
    [TEST/mkfs]   014-rootdir-inline-extent
    [TEST/mkfs]   015-fstree-uuid-otime
    [TEST/mkfs]   016-rootdir-bad-symbolic-link
    [TEST/mkfs]   017-small-backing-size-thin-provision-device
    [TEST/mkfs]   018-multidevice-overflow
    [TEST/mkfs]   019-basic-checksums-mkfs
    [TEST/mkfs]   020-basic-checksums-mount
    [TEST/mkfs]   021-rfeatures-quota-rootdir
    [TEST/mkfs]   022-rootdir-size
    [TEST/mkfs]   023-free-space-tree
    [TEST/mkfs]   024-fst-bitmaps
    [TEST/mkfs]   025-zoned-parallel
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   026-extent-tree-to-bgt
    [NOTRUN] block-group-tree tests are disabled
    [TEST/mkfs]   027-rootdir-inode
    [TEST/mkfs]   028-block-group-tree
    [NOTRUN] block-group-tree tests are disabled
    [TEST/mkfs]   029-raid-stripe-tree
    [NOTRUN] This test requires experimental build
    [TEST/mkfs]   030-zoned-rst
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   031-zoned-bgt
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   032-zoned-reset
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   033-zoned-reject-rst
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   034-rootdir-extra-hard-links
    [TEST/mkfs]   035-rootdir-cross-mount
    [TEST/mkfs]   036-rootdir-subvol
    [TEST/mkfs]   037-basic-compression
    [TEST/mkfs]   038-inode-flags
    [TEST/mkfs]   039-zoned-profiles
    [NOTRUN] zoned device tests are disabled
    [TEST/mkfs]   040-remap-tree
    [NOTRUN] btrfs check support for remap-tree missing
    [TEST/mkfs]   041-hole-detection
    [TEST/mkfs]   042-rootdir-contents
    [TEST/mkfs]   043-rootdir-reflink
  CC       btrfs-find-root.o
  LD       btrfs-find-root
  CC       btrfs-select-super.o
  LD       btrfs-select-super
  CC       convert/main.o
  CC       convert/common.o
  CC       convert/source-fs.o
  CC       convert/source-ext2.o
  CC       convert/source-reiserfs.o
  LD       btrfs-convert
  TEST     misc-tests.sh
    [TEST/misc]   001-btrfstune-features
    [TEST/misc]   002-uuid-rewrite
    [TEST/misc]   003-zero-log
    [TEST/misc]   004-shrink-fs
    [TEST/misc]   005-convert-progress-thread-crash
    [TEST/misc]   006-image-on-missing-device
    [TEST/misc]   007-subvolume-sync
    [TEST/misc]   008-leaf-crossing-stripes
    [TEST/misc]   009-subvolume-sync-must-wait
    [TEST/misc]   010-convert-delete-ext2-subvol
    [TEST/misc]   011-delete-missing-device
    [TEST/misc]   012-find-root-no-result
    [TEST/misc]   013-subvolume-sync-crash
    [TEST/misc]   014-filesystem-label
    [TEST/misc]   015-dump-super-garbage
    [TEST/misc]   016-send-clone-src
    [TEST/misc]   017-recv-stream-malformatted
    [TEST/misc]   018-recv-end-of-stream
    [TEST/misc]   019-receive-clones-on-mounted-subvol
    [TEST/misc]   020-fix-superblock-corruption
    [TEST/misc]   021-image-multi-devices
    [TEST/misc]   022-filesystem-du-on-empty-subvol
    [TEST/misc]   023-device-usage-with-missing-device
    [TEST/misc]   024-inspect-internal-rootid
    [TEST/misc]   025-zstd-compression
    [TEST/misc]   026-image-non-printable-chars
    [TEST/misc]   027-subvol-list-deleted-toplevel
    [TEST/misc]   028-superblock-recover
    [TEST/misc]   029-send-p-different-mountpoints
    [TEST/misc]   030-missing-device-image
    [TEST/misc]   031-qgroup-parent-child-relation
    [TEST/misc]   032-bad-item-ptr
    [TEST/misc]   033-filename-length-limit
    [TEST/misc]   034-metadata-uuid
    [TEST/misc]   035-receive-common-mount-point-prefix
    [NOTRUN] fix not available
    [TEST/misc]   036-receive-dump-invalid-stream
    [TEST/misc]   037-fi-show-on-new-file
    [TEST/misc]   038-backup-root-corruption
    [TEST/misc]   039-receive-clone-from-current-subvolume
    [TEST/misc]   040-subvolume-delete-default
    [TEST/misc]   041-subvolume-delete-during-send
    [TEST/misc]   042-inspect-internal-logical-resolve
    [TEST/misc]   043-subvolume-set-default-toplevel
    [TEST/misc]   045-receive-check-mount-type
    [TEST/misc]   046-seed-multi-mount
    [TEST/misc]   047-raid5-convert
    [TEST/misc]   048-image-restore-mount
    [TEST/misc]   049-btrfstune-transid-mismatch
    [TEST/misc]   050-receive-prop-ro-to-rw
    [TEST/misc]   051-warning-rw-subvol-received-uuid
    [TEST/misc]   052-seed-dirty-log
    [TEST/misc]   053-receive-write-encoded
    [NOTRUN] kernel does not support send stream >1
    [TEST/misc]   054-receive-dump-newlines
    [TEST/misc]   055-qgroup-clear-stale
    [TEST/misc]   056-subvolume-list-uuid
    [TEST/misc]   057-btrfstune-free-space-tree
    [TEST/misc]   058-replace-start-enqueue
    [TEST/misc]   059-qgroup-show-stale-qgroup-crash
    [TEST/misc]   060-ino-cache-clean
    [TEST/misc]   061-reverse-receive
    [TEST/misc]   062-fi-show-raw-dm-all-devices
    [TEST/misc]   063-btrfstune-zoned-bgt
    [NOTRUN] zoned device tests are disabled
    [TEST/misc]   064-csum-conversion-basic
    [NOTRUN] This test requires experimental build
    [TEST/misc]   065-csum-conversion-inject
    [NOTRUN] This test requires experimental build
    [TEST/misc]   066-image-filename
    [TEST/misc]   067-btrfstune-simple-quota
    [NOTRUN] This test requires experimental build
    [TEST/misc]   068-subvol-delete-recursive-show-child
    [TEST/misc]   069-btrfstune-resume-bgt
    [NOTRUN] block-group-tree tests are disabled
    [TEST/misc]   070-offline-resize
    [TEST/misc]   071-btrfstune-enable-remap-tree
    [NOTRUN] This test requires experimental build
  TEST     cli-tests.sh
    [TEST/cli]   001-btrfs
    [TEST/cli]   002-balance-full-no-filters
    [TEST/cli]   003-fi-resize-args
    [TEST/cli]   004-send-parent-multi-subvol
    [TEST/cli]   005-qgroup-show
    [TEST/cli]   006-qgroup-show-sync
    [TEST/cli]   007-check-force
    [TEST/cli]   008-subvolume-get-set-default
    [TEST/cli]   009-btrfstune
    [TEST/cli]   010-subvol-show-qgroup
    [TEST/cli]   011-defrag-recursion
    [TEST/cli]   012-fi-du-recursion
    [TEST/cli]   013-subvolume-delete-by-id
    [TEST/cli]   014-multiple-profiles-warning
    [TEST/cli]   015-defrag-compress
    [TEST/cli]   016-btrfs-fi-usage
    [TEST/cli]   017-fi-show-missing
    [TEST/cli]   019-subvolume-create-parents
    [TEST/cli]   020-dry-run
    [TEST/cli]   021-subvolume-multiple-arguments
    [TEST/cli]   022-fi-du-suffixes
    [TEST/cli]   023-device-delete-force
    [TEST/cli]   024-scrub-limit
    [TEST/cli]   025-subvolume-create-failures
  CC       btrfs-sb-mod.o
  LD       btrfs-sb-mod
  TEST     fuzz-tests.sh
    [TEST/fuzz]   001-simple-check-unmounted
    [TEST/fuzz]   002-simple-image
    [TEST/fuzz]   003-multi-check-unmounted
    [TEST/fuzz]   004-simple-dump-tree
    [TEST/fuzz]   005-simple-dump-super
    [TEST/fuzz]   006-simple-tree-stats
    [TEST/fuzz]   007-simple-super-recover
    [TEST/fuzz]   008-simple-chunk-recover
    [TEST/fuzz]   009-simple-zero-log
    [TEST/fuzz]   010-simple-sb
    [NOTRUN] custom test script not found or lacks execution permission ("/root/btrfs-progs/tests/fuzz-tests/images")
  LD       libbtrfsutil.so.1.4.0
  LN       libbtrfsutil.so.1
  LN       libbtrfsutil.so
  PY       libbtrfsutil
```

